### PR TITLE
Bazel support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --incompatible_enable_cc_toolchain_resolution

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ Source/ThirdParty/ANGLE/parsetab.py
 
 # Ignore user CMake presets
 CMakeUserPresets.json
+
+# bazels
+/bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ CMakeUserPresets.json
 
 # bazels
 /bazel-*
+/build
+log.txt

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,8 +8,10 @@ bazel build //:bun-webkit --platforms=//:linux_x64 -c opt
 ```
 
 """
+
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+load("//:bazel/install_clang.bzl", "CLANGPP_EXE", "CLANG_EXE")
 
 filegroup(
     name = "srcs",
@@ -41,6 +43,8 @@ cmake(
                                 "USE_PTHREAD_JIT_PERMISSIONS": "ON",
                                 "ENABLE_REMOTE_INSPECTOR": "ON",
                                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                                "CMAKE_C_COMPILER": CLANG_EXE,
+                                "CMAKE_CXX_COMPILER": CLANGPP_EXE,
                             },
                             "@platforms//os:linux": {
                                 "ENABLE_STATIC_JSC": "ON",
@@ -51,6 +55,8 @@ cmake(
                                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                                 "ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS": "ON",
                                 "ENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE": "ON",
+                                "CMAKE_C_COMPILER": CLANG_EXE,
+                                "CMAKE_CXX_COMPILER": CLANGPP_EXE,
                             },
                             "@platforms//os:windows": {},
                         },

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,6 +89,8 @@ cmake(
     out_static_libs = select(
         {
             "@platforms//os:linux": ["libJavaScriptCore.a"],
+            "@platforms//os:osx": ["libJavaScriptCore.a"],
+            "@platforms//os:windows": ["JavaScriptCore.lib"],
         },
         no_match_error = "Please provide platform",
     ),

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,8 @@ filegroup(
     visibility = ["//visibility:private"],
 )
 
+print("??????????????????? %s, %s" % (CLANG_EXE, CLANGPP_EXE))
+
 cmake(
     name = "bun-webkit",
     cache_entries = {
@@ -91,6 +93,17 @@ cmake(
     ],
     lib_source = ":srcs",
     tags = ["no-sandbox"],  # ccache need write access to cache dir
+    env = select({
+        "@platforms//os:osx": {
+            "CC": CLANG_EXE,
+            "CXX": CLANGPP_EXE,
+        },
+        "@platforms//os:linux": {
+            "CC": CLANG_EXE,
+            "CXX": CLANGPP_EXE,
+        },
+        "@platforms//os:windows": {},
+    }),
     # out_static_libs = ["libbun-webkit"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,159 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:private"],
+)
+
+cmake(
+    name = "bun-webkit",
+    cache_entries = {
+        "PORT": "JSCOnly",
+    },
+    generate_args = [
+        "-GNinja",
+    ] + select({
+        ":macOS": [
+            "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64",
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15",
+        ],
+        ":Windows": [
+            "-DCMAKE_SYSTEM_NAME=Windows",
+            "-DCMAKE_SYSTEM_VERSION=10.0",
+            "-DCMAKE_C_COMPILER=cl.exe",
+            "-DCMAKE_CXX_COMPILER=cl.exe",
+            "-DCMAKE_RC_COMPILER=rc.exe",
+            "-DCMAKE_LINKER=link.exe",
+            "-DCMAKE_RC_FLAGS=/nologo",
+            "-DCMAKE_CXX_FLAGS=/EHsc",
+            "-DCMAKE_CXX_FLAGS_DEBUG=/MTd",
+            "-DCMAKE_CXX_FLAGS_RELEASE=/MT",
+            "-DCMAKE_C_FLAGS=/EHsc",
+            "-DCMAKE_C_FLAGS_DEBUG=/MTd",
+            "-DCMAKE_C_FLAGS_RELEASE=/MT",
+            "-DCMAKE_EXE_LINKER_FLAGS=/SUBSYSTEM:WINDOWS",
+            "-DCMAKE_SHARED_LINKER_FLAGS=/SUBSYSTEM:WINDOWS",
+            "-DCMAKE_STATIC_LINKER_FLAGS=/SUBSYSTEM:WINDOWS",
+        ],
+        ":Linux": [
+            "-DCMAKE_SYSTEM_NAME=Linux",
+            "-DCMAKE_SYSTEM_VERSION=1",
+            "-DCMAKE_C_COMPILER=clang",
+            "-DCMAKE_CXX_COMPILER=clang++",
+            "-DCMAKE_LINKER=ld",
+            "-DCMAKE_CXX_FLAGS=-std=c++17",
+            "-DCMAKE_CXX_FLAGS_DEBUG=-g",
+            "-DCMAKE_CXX_FLAGS_RELEASE=-O3",
+            "-DCMAKE_C_FLAGS=-std=c11",
+            "-DCMAKE_C_FLAGS_DEBUG=-g",
+            "-DCMAKE_C_FLAGS_RELEASE=-O3",
+        ],
+    }),
+    lib_source = ":srcs",
+    out_static_libs = ["libbun-webkit"],
+)
+
+config_setting(
+    name = "os",
+    constraint_values = [
+        ":macOS",
+        ":Windows",
+        ":Linux",
+    ],
+)
+
+config_setting(
+    name = "arch",
+    constraint_values = [
+        ":x86",
+        ":x64",
+        ":arm64",
+    ],
+)
+
+# constraint_setting acts as an enum type, and constraint_value as an enum value.
+constraint_setting(name = "platform")
+
+constraint_value(
+    name = "macOS",
+    constraint_setting = "platform",
+)
+
+constraint_value(
+    name = "Windows",
+    constraint_setting = "platform",
+)
+
+constraint_value(
+    name = "Linux",
+    constraint_setting = "platform",
+)
+
+constraint_setting(name = "architecture")
+
+constraint_value(
+    name = "x86",
+    constraint_setting = "architecture",
+)
+
+constraint_value(
+    name = "x64",
+    constraint_setting = "architecture",
+)
+
+constraint_value(
+    name = "arm64",
+    constraint_setting = "architecture",
+)
+
+# Windows
+platform(
+    name = "win32",
+    constraint_values = [
+        ":Windows",
+        ":x86",
+    ],
+)
+
+platform(
+    name = "win64",
+    constraint_values = [
+        ":Windows",
+        ":x64",
+    ],
+)
+
+# macOS
+platform(
+    name = "mac_intel",
+    constraint_values = [
+        ":macOS",
+        ":x64",
+    ],
+)
+
+platform(
+    name = "mac_apple_silicon",
+    constraint_values = [
+        ":macOS",
+        ":arm64",
+    ],
+)
+
+# Linux
+platform(
+    name = "linux_x86",
+    constraint_values = [
+        ":Linux",
+        ":x86",
+    ],
+)
+
+platform(
+    name = "linux_x64",
+    constraint_values = [
+        ":Linux",
+        ":x64",
+    ],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,10 +23,10 @@ cmake(
     cache_entries = {
                         "PORT": "JSCOnly",  # Port
                     } |
-                    # Platform
+                    # Platform related definitions
                     select(
                         {
-                            ":macOS": {
+                            "@platforms//os:osx": {
                                 "ENABLE_STATIC_JSC": "ON",
                                 "ENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE": "ON",
                                 "ENABLE_BUN_SKIP_FAILING_ASSERTIONS": "ON",
@@ -43,7 +43,7 @@ cmake(
                                 "ENABLE_REMOTE_INSPECTOR": "ON",
                                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                             },
-                            ":Linux": {
+                            "@platforms//os:linux": {
                                 "ENABLE_STATIC_JSC": "ON",
                                 "ENABLE_BUN_SKIP_FAILING_ASSERTIONS": "ON",
                                 "USE_THIN_ARCHIVES": "OFF",
@@ -53,11 +53,11 @@ cmake(
                                 "ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS": "ON",
                                 "ENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE": "ON",
                             },
-                            ":Windows": {},
+                            "@platforms//os:windows": {},
                         },
                         no_match_error = "Please provide platform",
                     ) |
-                    # Architecture
+                    # Architecture related definitions
                     select(
                         {
                             ":mac_and_x64": {
@@ -104,99 +104,64 @@ cmake(
 config_setting(
     name = "os",
     constraint_values = [
-        ":macOS",
-        ":Windows",
-        ":Linux",
+        "@platforms//os:osx",
+        "@platforms//os:linux",
+        "@platforms//os:windows",
     ],
 )
 
 config_setting(
     name = "arch",
     constraint_values = [
-        ":x86",
-        ":x64",
-        ":arm64",
+        "@platforms//cpu:x86_32",
+        "@platforms//cpu:x86_64",
+        "@platforms//cpu:aarch64",
     ],
-)
-
-# constraint_setting acts as an enum type, and constraint_value as an enum value.
-constraint_setting(name = "platform")
-
-constraint_value(
-    name = "macOS",
-    constraint_setting = "platform",
-)
-
-constraint_value(
-    name = "Windows",
-    constraint_setting = "platform",
-)
-
-constraint_value(
-    name = "Linux",
-    constraint_setting = "platform",
-)
-
-constraint_setting(name = "architecture")
-
-constraint_value(
-    name = "x86",
-    constraint_setting = "architecture",
-)
-
-constraint_value(
-    name = "x64",
-    constraint_setting = "architecture",
-)
-
-constraint_value(
-    name = "arm64",
-    constraint_setting = "architecture",
 )
 
 # for condition AND of select
 selects.config_setting_group(
     name = "windows_and_x86",
     match_all = [
-        "//:Windows",
-        "//:x86",
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_32",
     ],
 )
 selects.config_setting_group(
     name = "windows_and_x64",
     match_all = [
-        "//:Windows",
-        "//:x64",
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
 )
 
 selects.config_setting_group(
     name = "mac_and_x64",
     match_all = [
-        "//:macOS",
-        "//:x64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
 )
 selects.config_setting_group(
     name = "mac_and_arm64",
     match_all = [
-        "//:macOS",
-        "//:arm64",
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
     ],
 )
 
 selects.config_setting_group(
     name = "linux_and_x86",
     match_all = [
-        "//:Linux",
-        "//:x86",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_32",
     ],
 )
 selects.config_setting_group(
     name = "linux_and_x64",
     match_all = [
-        "//:Linux",
-        "//:x64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
 )
 
@@ -205,16 +170,16 @@ selects.config_setting_group(
 platform(
     name = "win32",
     constraint_values = [
-        ":Windows",
-        ":x86",
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_32",
     ],
 )
 
 platform(
     name = "win64",
     constraint_values = [
-        ":Windows",
-        ":x64",
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
 )
 
@@ -222,16 +187,16 @@ platform(
 platform(
     name = "mac_intel",
     constraint_values = [
-        ":macOS",
-        ":x64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
 )
 
 platform(
     name = "mac_apple_silicon",
     constraint_values = [
-        ":macOS",
-        ":arm64",
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
     ],
 )
 
@@ -239,15 +204,15 @@ platform(
 platform(
     name = "linux_x86",
     constraint_values = [
-        ":Linux",
-        ":x86",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_32",
     ],
 )
 
 platform(
     name = "linux_x64",
     constraint_values = [
-        ":Linux",
-        ":x64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,16 @@
+"""
+Build script for bun-webkit
+
+
+## Build
+```
+bazel build //:bun-webkit --platforms=//:linux_x64 -c opt
+```
+
+"""
+
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 filegroup(
     name = "srcs",
@@ -9,49 +21,84 @@ filegroup(
 cmake(
     name = "bun-webkit",
     cache_entries = {
-        "PORT": "JSCOnly",
-    },
+                        "PORT": "JSCOnly",  # Port
+                    } |
+                    # Platform
+                    select(
+                        {
+                            ":macOS": {
+                                "ENABLE_STATIC_JSC": "ON",
+                                "ENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE": "ON",
+                                "ENABLE_BUN_SKIP_FAILING_ASSERTIONS": "ON",
+                                "USE_THIN_ARCHIVES": "OFF",
+                                "ENABLE_FTL_JIT": "ON",
+                                "USE_BUN_JSC_ADDITIONS": "ON",
+                                "CMAKE_EXE_LINKER_FLAGS": "-fuse-ld=lld",
+                                "CMAKE_AR": "$(which llvm-ar)",
+                                "CMAKE_RANLIB": "$(which llvm-ranlib)",
+                                "ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS": "ON",
+                                "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+                                "PTHREAD_JIT_PERMISSIONS_API": "1",
+                                "USE_PTHREAD_JIT_PERMISSIONS": "ON",
+                                "ENABLE_REMOTE_INSPECTOR": "ON",
+                                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                            },
+                            ":Linux": {
+                                "ENABLE_STATIC_JSC": "ON",
+                                "ENABLE_BUN_SKIP_FAILING_ASSERTIONS": "ON",
+                                "USE_THIN_ARCHIVES": "OFF",
+                                "USE_BUN_JSC_ADDITIONS": "ON",
+                                "ENABLE_FTL_JIT": "ON",
+                                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                                "ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS": "ON",
+                                "ENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE": "ON",
+                            },
+                            ":Windows": {},
+                        },
+                        no_match_error = "Please provide platform",
+                    ) |
+                    # Architecture
+                    select(
+                        {
+                            ":mac_and_x64": {
+                                "CMAKE_OSX_ARCHITECTURES": "x86_64",
+                            },
+                            ":mac_and_arm64": {
+                                "CMAKE_OSX_ARCHITECTURES": "arm64",
+                            },
+                            ":linux_and_x86": {
+                                "CMAKE_CXX_FLAGS": "-m32",
+                                "CMAKE_C_FLAGS": "-m32",
+                                "CMAKE_EXE_LINKER_FLAGS": "-m32",
+                                "CMAKE_SHARED_LINKER_FLAGS": "-m32",
+                            },
+                            ":linux_and_x64": {
+                                "CMAKE_CXX_FLAGS": "-m64",
+                                "CMAKE_C_FLAGS": "-m64",
+                                "CMAKE_EXE_LINKER_FLAGS": "-m64",
+                                "CMAKE_SHARED_LINKER_FLAGS": "-m64",
+                            },
+                            ":windows_and_x86": {
+                                "CMAKE_CXX_FLAGS": "-m32",
+                                "CMAKE_C_FLAGS": "-m32",
+                                "CMAKE_EXE_LINKER_FLAGS": "-m32",
+                                "CMAKE_SHARED_LINKER_FLAGS": "-m32",
+                            },
+                            ":windows_and_x64": {
+                                "CMAKE_CXX_FLAGS": "-m64",
+                                "CMAKE_C_FLAGS": "-m64",
+                                "CMAKE_EXE_LINKER_FLAGS": "-m64",
+                                "CMAKE_SHARED_LINKER_FLAGS": "-m64",
+                            },
+                        },
+                        no_match_error = "Please provide platform",
+                    ),
     generate_args = [
         "-GNinja",
-    ] + select({
-        ":macOS": [
-            "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64",
-            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15",
-        ],
-        ":Windows": [
-            "-DCMAKE_SYSTEM_NAME=Windows",
-            "-DCMAKE_SYSTEM_VERSION=10.0",
-            "-DCMAKE_C_COMPILER=cl.exe",
-            "-DCMAKE_CXX_COMPILER=cl.exe",
-            "-DCMAKE_RC_COMPILER=rc.exe",
-            "-DCMAKE_LINKER=link.exe",
-            "-DCMAKE_RC_FLAGS=/nologo",
-            "-DCMAKE_CXX_FLAGS=/EHsc",
-            "-DCMAKE_CXX_FLAGS_DEBUG=/MTd",
-            "-DCMAKE_CXX_FLAGS_RELEASE=/MT",
-            "-DCMAKE_C_FLAGS=/EHsc",
-            "-DCMAKE_C_FLAGS_DEBUG=/MTd",
-            "-DCMAKE_C_FLAGS_RELEASE=/MT",
-            "-DCMAKE_EXE_LINKER_FLAGS=/SUBSYSTEM:WINDOWS",
-            "-DCMAKE_SHARED_LINKER_FLAGS=/SUBSYSTEM:WINDOWS",
-            "-DCMAKE_STATIC_LINKER_FLAGS=/SUBSYSTEM:WINDOWS",
-        ],
-        ":Linux": [
-            "-DCMAKE_SYSTEM_NAME=Linux",
-            "-DCMAKE_SYSTEM_VERSION=1",
-            "-DCMAKE_C_COMPILER=clang",
-            "-DCMAKE_CXX_COMPILER=clang++",
-            "-DCMAKE_LINKER=ld",
-            "-DCMAKE_CXX_FLAGS=-std=c++17",
-            "-DCMAKE_CXX_FLAGS_DEBUG=-g",
-            "-DCMAKE_CXX_FLAGS_RELEASE=-O3",
-            "-DCMAKE_C_FLAGS=-std=c11",
-            "-DCMAKE_C_FLAGS_DEBUG=-g",
-            "-DCMAKE_C_FLAGS_RELEASE=-O3",
-        ],
-    }),
+    ],
     lib_source = ":srcs",
-    out_static_libs = ["libbun-webkit"],
+    tags = ["no-sandbox"],  # ccache need write access to cache dir
+    # out_static_libs = ["libbun-webkit"],
 )
 
 config_setting(
@@ -106,6 +153,53 @@ constraint_value(
     name = "arm64",
     constraint_setting = "architecture",
 )
+
+# for condition AND of select
+selects.config_setting_group(
+    name = "windows_and_x86",
+    match_all = [
+        "//:Windows",
+        "//:x86",
+    ],
+)
+selects.config_setting_group(
+    name = "windows_and_x64",
+    match_all = [
+        "//:Windows",
+        "//:x64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "mac_and_x64",
+    match_all = [
+        "//:macOS",
+        "//:x64",
+    ],
+)
+selects.config_setting_group(
+    name = "mac_and_arm64",
+    match_all = [
+        "//:macOS",
+        "//:arm64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_and_x86",
+    match_all = [
+        "//:Linux",
+        "//:x86",
+    ],
+)
+selects.config_setting_group(
+    name = "linux_and_x64",
+    match_all = [
+        "//:Linux",
+        "//:x64",
+    ],
+)
+
 
 # Windows
 platform(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,7 +11,7 @@ bazel build //:bun-webkit --platforms=//:linux_x64 -c opt
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-load("//:bazel/install_clang.bzl", "CLANGPP_EXE", "CLANG_EXE")
+load("//bazel:install_clang.bzl", "CLANGPP_EXE", "CLANG_EXE")
 
 filegroup(
     name = "srcs",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,15 +11,13 @@ bazel build //:bun-webkit --platforms=//:linux_x64 -c opt
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-load("//bazel:install_clang.bzl", "CLANGPP_EXE", "CLANG_EXE")
+# load("//bazel:install_clang.bzl", "CLANGPP_EXE", "CLANG_EXE")
 
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
     visibility = ["//visibility:private"],
 )
-
-print("??????????????????? %s, %s" % (CLANG_EXE, CLANGPP_EXE))
 
 cmake(
     name = "bun-webkit",
@@ -45,8 +43,6 @@ cmake(
                                 "USE_PTHREAD_JIT_PERMISSIONS": "ON",
                                 "ENABLE_REMOTE_INSPECTOR": "ON",
                                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                                "CMAKE_C_COMPILER": CLANG_EXE,
-                                "CMAKE_CXX_COMPILER": CLANGPP_EXE,
                             },
                             "@platforms//os:linux": {
                                 "ENABLE_STATIC_JSC": "ON",
@@ -57,8 +53,6 @@ cmake(
                                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                                 "ALLOW_LINE_AND_COLUMN_NUMBER_IN_BUILTINS": "ON",
                                 "ENABLE_SINGLE_THREADED_VM_ENTRY_SCOPE": "ON",
-                                "CMAKE_C_COMPILER": CLANG_EXE,
-                                "CMAKE_CXX_COMPILER": CLANGPP_EXE,
                             },
                             "@platforms//os:windows": {},
                         },
@@ -92,19 +86,14 @@ cmake(
         "-GNinja",
     ],
     lib_source = ":srcs",
+    out_static_libs = select(
+        {
+            "@platforms//os:linux": ["libJavaScriptCore.a"],
+        },
+        no_match_error = "Please provide platform",
+    ),
     tags = ["no-sandbox"],  # ccache need write access to cache dir
-    env = select({
-        "@platforms//os:osx": {
-            "CC": CLANG_EXE,
-            "CXX": CLANGPP_EXE,
-        },
-        "@platforms//os:linux": {
-            "CC": CLANG_EXE,
-            "CXX": CLANGPP_EXE,
-        },
-        "@platforms//os:windows": {},
-    }),
-    # out_static_libs = ["libbun-webkit"],
+    targets = ["JavaScriptCore"],
 )
 
 config_setting(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,9 +8,8 @@ bazel build //:bun-webkit --platforms=//:linux_x64 -c opt
 ```
 
 """
-
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -127,6 +126,7 @@ selects.config_setting_group(
         "@platforms//cpu:x86_32",
     ],
 )
+
 selects.config_setting_group(
     name = "windows_and_x64",
     match_all = [
@@ -142,6 +142,7 @@ selects.config_setting_group(
         "@platforms//cpu:x86_64",
     ],
 )
+
 selects.config_setting_group(
     name = "mac_and_arm64",
     match_all = [
@@ -157,6 +158,7 @@ selects.config_setting_group(
         "@platforms//cpu:x86_32",
     ],
 )
+
 selects.config_setting_group(
     name = "linux_and_x64",
     match_all = [
@@ -164,7 +166,6 @@ selects.config_setting_group(
         "@platforms//cpu:x86_64",
     ],
 )
-
 
 # Windows
 platform(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,23 +65,11 @@ cmake(
                             ":mac_and_arm64": {
                                 "CMAKE_OSX_ARCHITECTURES": "arm64",
                             },
-                            ":linux_and_x86": {
-                                "CMAKE_CXX_FLAGS": "-m32",
-                                "CMAKE_C_FLAGS": "-m32",
-                                "CMAKE_EXE_LINKER_FLAGS": "-m32",
-                                "CMAKE_SHARED_LINKER_FLAGS": "-m32",
-                            },
                             ":linux_and_x64": {
                                 "CMAKE_CXX_FLAGS": "-m64",
                                 "CMAKE_C_FLAGS": "-m64",
                                 "CMAKE_EXE_LINKER_FLAGS": "-m64",
                                 "CMAKE_SHARED_LINKER_FLAGS": "-m64",
-                            },
-                            ":windows_and_x86": {
-                                "CMAKE_CXX_FLAGS": "-m32",
-                                "CMAKE_C_FLAGS": "-m32",
-                                "CMAKE_EXE_LINKER_FLAGS": "-m32",
-                                "CMAKE_SHARED_LINKER_FLAGS": "-m32",
                             },
                             ":windows_and_x64": {
                                 "CMAKE_CXX_FLAGS": "-m64",
@@ -112,21 +100,12 @@ config_setting(
 config_setting(
     name = "arch",
     constraint_values = [
-        "@platforms//cpu:x86_32",
         "@platforms//cpu:x86_64",
         "@platforms//cpu:aarch64",
     ],
 )
 
 # for condition AND of select
-selects.config_setting_group(
-    name = "windows_and_x86",
-    match_all = [
-        "@platforms//os:windows",
-        "@platforms//cpu:x86_32",
-    ],
-)
-
 selects.config_setting_group(
     name = "windows_and_x64",
     match_all = [
@@ -152,14 +131,6 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
-    name = "linux_and_x86",
-    match_all = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_32",
-    ],
-)
-
-selects.config_setting_group(
     name = "linux_and_x64",
     match_all = [
         "@platforms//os:linux",
@@ -168,14 +139,6 @@ selects.config_setting_group(
 )
 
 # Windows
-platform(
-    name = "win32",
-    constraint_values = [
-        "@platforms//os:windows",
-        "@platforms//cpu:x86_32",
-    ],
-)
-
 platform(
     name = "win64",
     constraint_values = [
@@ -202,14 +165,6 @@ platform(
 )
 
 # Linux
-platform(
-    name = "linux_x86",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_32",
-    ],
-)
-
 platform(
     name = "linux_x64",
     constraint_values = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,3 +47,9 @@ endif ()
 # Print the features list last, for maximum visibility.
 # -----------------------------------------------------------------------------
 PRINT_WEBKIT_OPTIONS()
+
+# HACK: rules_foreign_cc cmake requires that target to be installed
+# in order to tell build process is succeded or not.
+install(
+    TARGETS JavaScriptCore DESTINATION lib
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,14 @@
+"""
+To use this module:
+
+in MODULE.bazel
+```
+bazel_dep(name = "bun-webkit", version = "0.0.1")
+local_path_override(name = "bun-webkit", path = "PATH_TO_THIS_MODULE")
+```
+
+optionally add this to `https://github.com/bazelbuild/bazel-central-registry`
+
+"""
+
+module(name = "bun-webkit", version = "1.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,3 +20,10 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 rules_foreign_cc_dependencies()
 
 # Rules ForeignCc  end
+
+
+# Skylib start
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+# Skylib end

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,22 @@
+workspace(name = "com_github_oven-sh_webkit")
+
+
+# Rules ForeignCc  start
+# https://bazelbuild.github.io/rules_foreign_cc/main/index.html#setup
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_foreign_cc",
+    # TODO: Get the latest sha256 value from a bazel debug message or the latest 
+    #       release on the releases page: https://github.com/bazelbuild/rules_foreign_cc/releases
+    #
+    # sha256 = "...",
+    strip_prefix = "rules_foreign_cc-7b673547a3b51febb4e67642bf0cc30c3ba09453",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/7b673547a3b51febb4e67642bf0cc30c3ba09453.tar.gz",
+)
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
+# Rules ForeignCc  end

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,10 @@ bazel_skylib_workspace()
 # Skylib end
 
 
+# install clang for macOS or Ubuntu
+load("//:bazel/install_clang.bzl", "install_clang")
+install_clang()
+
 # llvm start
 # BAZEL_TOOLCHAIN_TAG = "0.8.2"
 # BAZEL_TOOLCHAIN_SHA = "0fc3a2b0c9c929920f4bed8f2b446a8274cad41f5ee823fd3faa0d7641f20db0"
@@ -54,6 +58,3 @@ bazel_skylib_workspace()
 # llvm_register_toolchains()
 
 ### llvm end
-
-load("//:bazel/install_clang.bzl", "install_clang")
-install_clang()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,8 +30,13 @@ bazel_skylib_workspace()
 
 
 # install clang for macOS or Ubuntu
-load("//:bazel/install_clang.bzl", "install_clang")
+load("//bazel:install_clang.bzl", "install_clang")
 install_clang()
+
+# register clang toolchains
+register_toolchains(
+    "//bazel/toolchains:clang_linux_toolchain",
+)
 
 # llvm start
 # BAZEL_TOOLCHAIN_TAG = "0.8.2"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,6 +36,7 @@ install_clang()
 # register clang toolchains
 register_toolchains(
     "//bazel/toolchains:clang_linux_toolchain",
+    "//bazel/toolchains:clang_darwin_toolchain",
 )
 
 # llvm start

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,27 +30,30 @@ bazel_skylib_workspace()
 
 
 # llvm start
-BAZEL_TOOLCHAIN_TAG = "0.8.2"
-BAZEL_TOOLCHAIN_SHA = "0fc3a2b0c9c929920f4bed8f2b446a8274cad41f5ee823fd3faa0d7641f20db0"
+# BAZEL_TOOLCHAIN_TAG = "0.8.2"
+# BAZEL_TOOLCHAIN_SHA = "0fc3a2b0c9c929920f4bed8f2b446a8274cad41f5ee823fd3faa0d7641f20db0"
 
-http_archive(
-    name = "com_grail_bazel_toolchain",
-    sha256 = BAZEL_TOOLCHAIN_SHA,
-    strip_prefix = "bazel-toolchain-{tag}".format(tag = BAZEL_TOOLCHAIN_TAG),
-    canonical_id = BAZEL_TOOLCHAIN_TAG,
-    url = "https://github.com/grailbio/bazel-toolchain/archive/refs/tags/{tag}.tar.gz".format(tag = BAZEL_TOOLCHAIN_TAG),
-)
+# http_archive(
+#     name = "com_grail_bazel_toolchain",
+#     sha256 = BAZEL_TOOLCHAIN_SHA,
+#     strip_prefix = "bazel-toolchain-{tag}".format(tag = BAZEL_TOOLCHAIN_TAG),
+#     canonical_id = BAZEL_TOOLCHAIN_TAG,
+#     url = "https://github.com/grailbio/bazel-toolchain/archive/refs/tags/{tag}.tar.gz".format(tag = BAZEL_TOOLCHAIN_TAG),
+# )
 
-load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
-bazel_toolchain_dependencies()
+# load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+# bazel_toolchain_dependencies()
 
-load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
-llvm_toolchain(
-    name = "llvm_toolchain",
-    llvm_version = "16.0.0",
-)
+# load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+# llvm_toolchain(
+#     name = "llvm_toolchain",
+#     llvm_version = "16.0.0",
+# )
 
-load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
-llvm_register_toolchains()
+# load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+# llvm_register_toolchains()
 
 ### llvm end
+
+load("//:bazel/install_clang.bzl", "install_clang")
+install_clang()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,3 +27,30 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 # Skylib end
+
+
+# llvm start
+BAZEL_TOOLCHAIN_TAG = "0.8.2"
+BAZEL_TOOLCHAIN_SHA = "0fc3a2b0c9c929920f4bed8f2b446a8274cad41f5ee823fd3faa0d7641f20db0"
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = BAZEL_TOOLCHAIN_SHA,
+    strip_prefix = "bazel-toolchain-{tag}".format(tag = BAZEL_TOOLCHAIN_TAG),
+    canonical_id = BAZEL_TOOLCHAIN_TAG,
+    url = "https://github.com/grailbio/bazel-toolchain/archive/refs/tags/{tag}.tar.gz".format(tag = BAZEL_TOOLCHAIN_TAG),
+)
+
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+bazel_toolchain_dependencies()
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "16.0.0",
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+llvm_register_toolchains()
+
+### llvm end

--- a/bazel/install_clang.bzl
+++ b/bazel/install_clang.bzl
@@ -1,0 +1,6 @@
+load(":bazel/install_clang_on_macos.bzl", "install_clang_on_macos")
+load(":bazel/install_clang_on_ubuntu.bzl", "install_clang_on_ubuntu")
+
+def install_clang():
+    install_clang_on_macos(name = "clang_on_macos")
+    install_clang_on_ubuntu(name = "clang_on_ubuntu")

--- a/bazel/install_clang.bzl
+++ b/bazel/install_clang.bzl
@@ -1,11 +1,13 @@
-load(":bazel/install_clang_on_macos.bzl", "install_clang_on_macos")
-load(":bazel/install_clang_on_ubuntu.bzl", "install_clang_on_ubuntu")
+load("//bazel:install_clang_on_macos.bzl", "install_clang_on_macos")
+load("//bazel:install_clang_on_ubuntu.bzl", "install_clang_on_ubuntu")
 
 LLVM_VERSION = "16"
 CLANG_EXE = "clang-%s" % LLVM_VERSION
 CLANGPP_EXE = "clang++-%s" % LLVM_VERSION
 LLVM_AR_EXE = "llvm-ar-%s" % LLVM_VERSION
 LLVM_RANLIB_EXE = "llvm-ranlib-%s" % LLVM_VERSION
+LLVM_LINKER_EXE = "lld-link-%s" % LLVM_VERSION
+LLVM_LINKER_MACOS_EXE = "ld64.lld-%s" % LLVM_VERSION
 
 def install_clang():
     install_clang_on_macos(
@@ -15,6 +17,7 @@ def install_clang():
         clangpp_exe = CLANGPP_EXE,
         llvm_ar_exe = LLVM_AR_EXE,
         llvm_ranlib_exe = LLVM_RANLIB_EXE,
+        llvm_linker_exe = LLVM_LINKER_MACOS_EXE,
     )
     install_clang_on_ubuntu(
         name = "clang_on_ubuntu",
@@ -23,4 +26,5 @@ def install_clang():
         clangpp_exe = CLANGPP_EXE,
         llvm_ar_exe = LLVM_AR_EXE,
         llvm_ranlib_exe = LLVM_RANLIB_EXE,
+        llvm_linker_exe = LLVM_LINKER_EXE,
     )

--- a/bazel/install_clang.bzl
+++ b/bazel/install_clang.bzl
@@ -1,6 +1,26 @@
 load(":bazel/install_clang_on_macos.bzl", "install_clang_on_macos")
 load(":bazel/install_clang_on_ubuntu.bzl", "install_clang_on_ubuntu")
 
+LLVM_VERSION = "16"
+CLANG_EXE = "clang-%s" % LLVM_VERSION
+CLANGPP_EXE = "clang++-%s" % LLVM_VERSION
+LLVM_AR_EXE = "llvm-ar-%s" % LLVM_VERSION
+LLVM_RANLIB_EXE = "llvm-ranlib-%s" % LLVM_VERSION
+
 def install_clang():
-    install_clang_on_macos(name = "clang_on_macos")
-    install_clang_on_ubuntu(name = "clang_on_ubuntu")
+    install_clang_on_macos(
+        name = "clang_on_macos",
+        llvm_version = LLVM_VERSION,
+        clang_exe = CLANG_EXE,
+        clangpp_exe = CLANGPP_EXE,
+        llvm_ar_exe = LLVM_AR_EXE,
+        llvm_ranlib_exe = LLVM_RANLIB_EXE,
+    )
+    install_clang_on_ubuntu(
+        name = "clang_on_ubuntu",
+        llvm_version = LLVM_VERSION,
+        clang_exe = CLANG_EXE,
+        clangpp_exe = CLANGPP_EXE,
+        llvm_ar_exe = LLVM_AR_EXE,
+        llvm_ranlib_exe = LLVM_RANLIB_EXE,
+    )

--- a/bazel/install_clang_on_macos.bzl
+++ b/bazel/install_clang_on_macos.bzl
@@ -2,13 +2,6 @@
 Installing clang on macOS using homebrew.
 """
 
-LLVM_VERSION = "16"
-LLVM_EXE = "clang-%s" % LLVM_VERSION
-CLANG_EXE = "clang-%s" % LLVM_VERSION
-CLANGPP_EXE = "clang++-%s" % LLVM_VERSION
-LLVM_AR_EXE = "llvm-ar-%s" % LLVM_VERSION
-LLVM_RANLIB_EXE = "llvm-ranlib-%s" % LLVM_VERSION
-
 def _install_home_brew(ctx):
     return ctx.execute([
         "curl",
@@ -18,16 +11,24 @@ def _install_home_brew(ctx):
         "bash -s",
     ])
 
-def _install_clang_on_macos(ctx):
+def _install_clang_on_macos_impl(ctx):
     """
     MacOS only rule to install clang on macOS using homebrew.
     """
+    LLVM_VERSION = ctx.attr.llvm_version
+    CLANG_EXE = ctx.attr.clang_exe
+    CLANGPP_EXE = ctx.attr.clangpp_exe
+    LLVM_AR_EXE = ctx.attr.llvm_ar_exe
+    LLVM_RANLIB_EXE = ctx.attr.llvm_ranlib_exe
+
+    # hack to prevent ERROR: install_clang_on_ubuntu rule //external:clang_on_macos must create a directory
+    ctx.file(".ignores_me", "")
+
     if ctx.os.name != "macos" or \
-       (ctx.which("clang-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("clang++-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("llvm-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("llvm-ar-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("llvm-ranlib-%s" % LLVM_VERSION) == None):
+       (ctx.which(CLANG_EXE) == None) or \
+       (ctx.which(CLANGPP_EXE) == None) or \
+       (ctx.which(LLVM_AR_EXE) == None) or \
+       (ctx.which(LLVM_RANLIB_EXE) == None):
         return
 
     if ctx.which("brew") == None:
@@ -38,7 +39,13 @@ def _install_clang_on_macos(ctx):
         ctx.execute(["brew", "install", "llvm@%s" % LLVM_VERSION])
 
 install_clang_on_macos = repository_rule(
-    implementation = _install_clang_on_macos,
-    attrs = {},
+    implementation = _install_clang_on_macos_impl,
+    attrs = {
+        "llvm_version": attr.string(mandatory=True),
+        "clang_exe": attr.string(mandatory=True),
+        "clangpp_exe": attr.string(mandatory=True),
+        "llvm_ar_exe": attr.string(mandatory=True),
+        "llvm_ranlib_exe": attr.string(mandatory=True),
+    },
     doc = "Installing clang on macOS",
 )

--- a/bazel/install_clang_on_macos.bzl
+++ b/bazel/install_clang_on_macos.bzl
@@ -1,24 +1,44 @@
 """
-This file contains rules that are specific to the repository.
+Installing clang on macOS using homebrew.
 """
 
-def _install_home_brew(ctx):
-    ctx.run('/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
+LLVM_VERSION = "16"
+LLVM_EXE = "clang-%s" % LLVM_VERSION
+CLANG_EXE = "clang-%s" % LLVM_VERSION
+CLANGPP_EXE = "clang++-%s" % LLVM_VERSION
+LLVM_AR_EXE = "llvm-ar-%s" % LLVM_VERSION
+LLVM_RANLIB_EXE = "llvm-ranlib-%s" % LLVM_VERSION
 
+def _install_home_brew(ctx):
+    return ctx.execute([
+        "curl",
+        "-s",
+        "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh",
+        "|",
+        "bash -s",
+    ])
 
 def _install_clang_on_macos(ctx):
     """
     MacOS only rule to install clang on macOS using homebrew.
     """
-    if ctx.os.name != 'macos':
+    if ctx.os.name != "macos" or \
+       (ctx.which("clang-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("clang++-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("llvm-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("llvm-ar-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("llvm-ranlib-%s" % LLVM_VERSION) == None):
         return
 
-    _install_home_brew(ctx)
-    ctx.run('brew install llvm@16')
-
+    if ctx.which("brew") == None:
+        what = _install_home_brew(ctx)
+        if what.return_code == 0:
+            ctx.execute(["brew", "install", "llvm@%s" % LLVM_VERSION])
+    else:
+        ctx.execute(["brew", "install", "llvm@%s" % LLVM_VERSION])
 
 install_clang_on_macos = repository_rule(
     implementation = _install_clang_on_macos,
     attrs = {},
-    doc = 'Installing clang on macOS',
+    doc = "Installing clang on macOS",
 )

--- a/bazel/install_clang_on_macos.bzl
+++ b/bazel/install_clang_on_macos.bzl
@@ -20,6 +20,7 @@ def _install_clang_on_macos_impl(ctx):
     CLANGPP_EXE = ctx.attr.clangpp_exe
     LLVM_AR_EXE = ctx.attr.llvm_ar_exe
     LLVM_RANLIB_EXE = ctx.attr.llvm_ranlib_exe
+    LLVM_LINKER_EXE = ctx.attr.llvm_linker_exe
 
     # hack to prevent ERROR: install_clang_on_ubuntu rule //external:clang_on_macos must create a directory
     ctx.file(".ignores_me", "")
@@ -28,7 +29,8 @@ def _install_clang_on_macos_impl(ctx):
        (ctx.which(CLANG_EXE) == None) or \
        (ctx.which(CLANGPP_EXE) == None) or \
        (ctx.which(LLVM_AR_EXE) == None) or \
-       (ctx.which(LLVM_RANLIB_EXE) == None):
+       (ctx.which(LLVM_RANLIB_EXE) == None) or \
+       (ctx.which(LLVM_LINKER_EXE) == None):
         return
 
     if ctx.which("brew") == None:
@@ -41,11 +43,12 @@ def _install_clang_on_macos_impl(ctx):
 install_clang_on_macos = repository_rule(
     implementation = _install_clang_on_macos_impl,
     attrs = {
-        "llvm_version": attr.string(mandatory=True),
-        "clang_exe": attr.string(mandatory=True),
-        "clangpp_exe": attr.string(mandatory=True),
-        "llvm_ar_exe": attr.string(mandatory=True),
-        "llvm_ranlib_exe": attr.string(mandatory=True),
+        "llvm_version": attr.string(mandatory = True),
+        "clang_exe": attr.string(mandatory = True),
+        "clangpp_exe": attr.string(mandatory = True),
+        "llvm_ar_exe": attr.string(mandatory = True),
+        "llvm_ranlib_exe": attr.string(mandatory = True),
+        "llvm_linker_exe": attr.string(mandatory = True),
     },
     doc = "Installing clang on macOS",
 )

--- a/bazel/install_clang_on_macos.bzl
+++ b/bazel/install_clang_on_macos.bzl
@@ -1,0 +1,24 @@
+"""
+This file contains rules that are specific to the repository.
+"""
+
+def _install_home_brew(ctx):
+    ctx.run('/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
+
+
+def _install_clang_on_macos(ctx):
+    """
+    MacOS only rule to install clang on macOS using homebrew.
+    """
+    if ctx.os.name != 'macos':
+        return
+
+    _install_home_brew(ctx)
+    ctx.run('brew install llvm@16')
+
+
+install_clang_on_macos = repository_rule(
+    implementation = _install_clang_on_macos,
+    attrs = {},
+    doc = 'Installing clang on macOS',
+)

--- a/bazel/install_clang_on_ubuntu.bzl
+++ b/bazel/install_clang_on_ubuntu.bzl
@@ -20,12 +20,14 @@ def _install_clang_on_ubuntu(ctx):
     CLANGPP_EXE = ctx.attr.clangpp_exe
     LLVM_AR_EXE = ctx.attr.llvm_ar_exe
     LLVM_RANLIB_EXE = ctx.attr.llvm_ranlib_exe
+    LLVM_LINKER_EXE = ctx.attr.llvm_linker_exe
 
     if ctx.os.name != "linux" or \
        (ctx.which(CLANG_EXE) == None) or \
        (ctx.which(CLANGPP_EXE) == None) or \
        (ctx.which(LLVM_AR_EXE) == None) or \
-       (ctx.which(LLVM_RANLIB_EXE) == None):
+       (ctx.which(LLVM_RANLIB_EXE) == None) or \
+       (ctx.which(LLVM_LINKER_EXE) == None):
         return
     what = _download_and_run_llvm_script(ctx)
     if what.return_code == 0:
@@ -42,11 +44,12 @@ def _install_clang_on_ubuntu(ctx):
 install_clang_on_ubuntu = repository_rule(
     implementation = _install_clang_on_ubuntu,
     attrs = {
-        "llvm_version": attr.string(mandatory=True),
-        "clang_exe": attr.string(mandatory=True),
-        "clangpp_exe": attr.string(mandatory=True),
-        "llvm_ar_exe": attr.string(mandatory=True),
-        "llvm_ranlib_exe": attr.string(mandatory=True),
+        "llvm_version": attr.string(mandatory = True),
+        "clang_exe": attr.string(mandatory = True),
+        "clangpp_exe": attr.string(mandatory = True),
+        "llvm_ar_exe": attr.string(mandatory = True),
+        "llvm_ranlib_exe": attr.string(mandatory = True),
+        "llvm_linker_exe": attr.string(mandatory = True),
     },
     doc = "Install LLVM using official script",
 )

--- a/bazel/install_clang_on_ubuntu.bzl
+++ b/bazel/install_clang_on_ubuntu.bzl
@@ -3,14 +3,8 @@ Install LLVM using official script
 
 """
 
-LLVM_VERSION = "16"
-LLVM_EXE = "clang-%s" % LLVM_VERSION
-CLANG_EXE = "clang-%s" % LLVM_VERSION
-CLANGPP_EXE = "clang++-%s" % LLVM_VERSION
-LLVM_AR_EXE = "llvm-ar-%s" % LLVM_VERSION
-LLVM_RANLIB_EXE = "llvm-ranlib-%s" % LLVM_VERSION
-
 def _download_and_run_llvm_script(ctx):
+    LLVM_VERSION = ctx.attr.llvm_version
     return ctx.execute(["sudo", "curl", "-s", "https://apt.llvm.org/llvm.sh", "|", "bash -s", LLVM_VERSION])
 
 def _install_clang_on_ubuntu(ctx):
@@ -21,12 +15,17 @@ def _install_clang_on_ubuntu(ctx):
     # hack to prevent ERROR: install_clang_on_ubuntu rule //external:clang_on_ubuntu must create a directory
     ctx.file(".ignores_me", "")
 
+    LLVM_VERSION = ctx.attr.llvm_version
+    CLANG_EXE = ctx.attr.clang_exe
+    CLANGPP_EXE = ctx.attr.clangpp_exe
+    LLVM_AR_EXE = ctx.attr.llvm_ar_exe
+    LLVM_RANLIB_EXE = ctx.attr.llvm_ranlib_exe
+
     if ctx.os.name != "linux" or \
-       (ctx.which("clang-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("clang++-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("llvm-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("llvm-ar-%s" % LLVM_VERSION) == None) or \
-       (ctx.which("llvm-ranlib-%s" % LLVM_VERSION) == None):
+       (ctx.which(CLANG_EXE) == None) or \
+       (ctx.which(CLANGPP_EXE) == None) or \
+       (ctx.which(LLVM_AR_EXE) == None) or \
+       (ctx.which(LLVM_RANLIB_EXE) == None):
         return
     what = _download_and_run_llvm_script(ctx)
     if what.return_code == 0:
@@ -35,13 +34,19 @@ def _install_clang_on_ubuntu(ctx):
             "apt-get",
             "install",
             "-y",
-            "clang-%s" % LLVM_VERSION,
-            "clang++-%s" % LLVM_VERSION,
+            CLANG_EXE,
+            CLANGPP_EXE,
             "llvm-%s" % LLVM_VERSION,  # includs ar and ranlib
         ])
 
 install_clang_on_ubuntu = repository_rule(
     implementation = _install_clang_on_ubuntu,
-    attrs = {},
+    attrs = {
+        "llvm_version": attr.string(mandatory=True),
+        "clang_exe": attr.string(mandatory=True),
+        "clangpp_exe": attr.string(mandatory=True),
+        "llvm_ar_exe": attr.string(mandatory=True),
+        "llvm_ranlib_exe": attr.string(mandatory=True),
+    },
     doc = "Install LLVM using official script",
 )

--- a/bazel/install_clang_on_ubuntu.bzl
+++ b/bazel/install_clang_on_ubuntu.bzl
@@ -4,24 +4,44 @@ Install LLVM using official script
 """
 
 LLVM_VERSION = "16"
+LLVM_EXE = "clang-%s" % LLVM_VERSION
+CLANG_EXE = "clang-%s" % LLVM_VERSION
+CLANGPP_EXE = "clang++-%s" % LLVM_VERSION
+LLVM_AR_EXE = "llvm-ar-%s" % LLVM_VERSION
+LLVM_RANLIB_EXE = "llvm-ranlib-%s" % LLVM_VERSION
 
 def _download_and_run_llvm_script(ctx):
-    ctx.run("bash <(curl -s https://apt.llvm.org/llvm.sh) %s" % LLVM_VERSION)
+    return ctx.execute(["sudo", "curl", "-s", "https://apt.llvm.org/llvm.sh", "|", "bash -s", LLVM_VERSION])
 
 def _install_clang_on_ubuntu(ctx):
     """
     Linux only rule to install LLVM using official script
     """
-    print("Installing LLVM using official script %s" % LLVM_VERSION)
-    print("os.name: %s" % ctx.os.name)
 
-    if ctx.os.name != 'linux':
+    # hack to prevent ERROR: install_clang_on_ubuntu rule //external:clang_on_ubuntu must create a directory
+    ctx.file(".ignores_me", "")
+
+    if ctx.os.name != "linux" or \
+       (ctx.which("clang-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("clang++-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("llvm-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("llvm-ar-%s" % LLVM_VERSION) == None) or \
+       (ctx.which("llvm-ranlib-%s" % LLVM_VERSION) == None):
         return
-    _download_and_run_llvm_script(ctx)
-    ctx.run("sudo apt-get install -y clang-%s clang++-%s llvm-%s llvm-ar-%s llvm-ranlib-%s" % (LLVM_VERSION, LLVM_VERSION, LLVM_VERSION, LLVM_VERSION, LLVM_VERSION))
+    what = _download_and_run_llvm_script(ctx)
+    if what.return_code == 0:
+        ctx.execute([
+            "sudo",
+            "apt-get",
+            "install",
+            "-y",
+            "clang-%s" % LLVM_VERSION,
+            "clang++-%s" % LLVM_VERSION,
+            "llvm-%s" % LLVM_VERSION,  # includs ar and ranlib
+        ])
 
 install_clang_on_ubuntu = repository_rule(
-    implementation=_install_clang_on_ubuntu,
-    attrs={},
-    doc="Install LLVM using official script",
+    implementation = _install_clang_on_ubuntu,
+    attrs = {},
+    doc = "Install LLVM using official script",
 )

--- a/bazel/install_clang_on_ubuntu.bzl
+++ b/bazel/install_clang_on_ubuntu.bzl
@@ -1,0 +1,27 @@
+"""
+Install LLVM using official script
+
+"""
+
+LLVM_VERSION = "16"
+
+def _download_and_run_llvm_script(ctx):
+    ctx.run("bash <(curl -s https://apt.llvm.org/llvm.sh) %s" % LLVM_VERSION)
+
+def _install_clang_on_ubuntu(ctx):
+    """
+    Linux only rule to install LLVM using official script
+    """
+    print("Installing LLVM using official script %s" % LLVM_VERSION)
+    print("os.name: %s" % ctx.os.name)
+
+    if ctx.os.name != 'linux':
+        return
+    _download_and_run_llvm_script(ctx)
+    ctx.run("sudo apt-get install -y clang-%s clang++-%s llvm-%s llvm-ar-%s llvm-ranlib-%s" % (LLVM_VERSION, LLVM_VERSION, LLVM_VERSION, LLVM_VERSION, LLVM_VERSION))
+
+install_clang_on_ubuntu = repository_rule(
+    implementation=_install_clang_on_ubuntu,
+    attrs={},
+    doc="Install LLVM using official script",
+)

--- a/bazel/toolchains/BUILD.bazel
+++ b/bazel/toolchains/BUILD.bazel
@@ -1,4 +1,5 @@
 load(":clang_linux.bzl", "cc_clang_linux_toolchain_config")
+load(":clang_darwin.bzl", "cc_clang_darwin_toolchain_config")
 
 cc_clang_linux_toolchain_config(name = "clang_linux_toolchain_config")
 filegroup(name = "empty")
@@ -29,6 +30,36 @@ toolchain(
         "@platforms//cpu:x86_64",
     ],
     toolchain = ":_clang_linux_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+cc_clang_darwin_toolchain_config(name = "clang_darwin_toolchain_config")
+cc_toolchain(
+    name = "_clang_darwin_toolchain",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    tags = ["no-sandbox"],
+    toolchain_config = ":clang_darwin_toolchain_config",
+    toolchain_identifier = "clang",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "clang_darwin_toolchain",
+    target_compatible_with = [
+        "@platforms//os:osx",
+    ],
+    exec_compatible_with = [
+        "@platforms//os:osx",
+    ],
+    toolchain = ":_clang_darwin_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     visibility = ["//visibility:public"],
 )

--- a/bazel/toolchains/BUILD.bazel
+++ b/bazel/toolchains/BUILD.bazel
@@ -1,0 +1,34 @@
+load(":clang_linux.bzl", "cc_clang_linux_toolchain_config")
+
+cc_clang_linux_toolchain_config(name = "clang_linux_toolchain_config")
+filegroup(name = "empty")
+cc_toolchain(
+    name = "_clang_linux_toolchain",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    tags = ["no-sandbox"],
+    toolchain_config = ":clang_linux_toolchain_config",
+    toolchain_identifier = "clang",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "clang_linux_toolchain",
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":_clang_linux_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/toolchains/clang_darwin.bzl
+++ b/bazel/toolchains/clang_darwin.bzl
@@ -1,0 +1,104 @@
+# NEW
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+# NEW
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+load("//bazel:install_clang.bzl", "LLVM_VERSION", "CLANG_EXE", "CLANGPP_EXE", "LLVM_LINKER_EXE", "LLVM_AR_EXE")
+
+all_link_actions = [
+    # NEW
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+def _cc_toolchain_config_impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            # path = "/usr/bin/clang",
+            path = "/opt/homebrew/opt/llvm@%s/bin/%s" % (LLVM_VERSION, CLANG_EXE),
+        ),
+        tool_path(
+            name = "ld",
+            path = "/opt/homebrew/opt/llvm@%s/bin/%s" % (LLVM_VERSION, LLVM_LINKER_EXE),
+        ),
+        tool_path(
+            name = "ar",
+            path = "/opt/homebrew/opt/llvm@%s/bin/%s" % (LLVM_VERSION, LLVM_AR_EXE),
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/opt/homebrew/opt/llvm@%s/bin/%s" % (LLVM_VERSION, CLANGPP_EXE),
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/bin/false",
+        ),
+    ]
+
+    features = [
+        # NEW
+        feature(
+            name = "default_linker_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-lc++",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,  # NEW
+        cxx_builtin_include_directories = [
+            # "/usr/lib/llvm-9/lib/clang/9.0.1/include",
+            "/usr/include",
+            # "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/",
+            "/opt/homebrew/opt/llvm/include/c++/v1",
+            "/opt/homebrew/opt/llvm/include",
+            "/opt/homebrew/Cellar/llvm/16.0.6/lib/clang/16/include",
+        ],
+        toolchain_identifier = "local",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_libc = "unknown",
+        target_cpu = "unknown",
+        compiler = "clang",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+cc_clang_darwin_toolchain_config = rule(
+    implementation = _cc_toolchain_config_impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/bazel/toolchains/clang_linux.bzl
+++ b/bazel/toolchains/clang_linux.bzl
@@ -9,7 +9,7 @@ load(
     "flag_set",
     "tool_path",
 )
-load("//bazel:install_clang.bzl", "CLANGPP_EXE", "LLVM_LINKER_EXE", "LLVM_AR_EXE")
+load("//bazel:install_clang.bzl", "CLANG_EXE", "CLANGPP_EXE", "LLVM_LINKER_EXE", "LLVM_AR_EXE")
 
 all_link_actions = [
     # NEW
@@ -23,7 +23,7 @@ def _cc_toolchain_config_impl(ctx):
         tool_path(
             name = "gcc",
             # path = "/usr/bin/clang",
-            path = "/usr/bin/%s" % CLANGPP_EXE,
+            path = "/usr/bin/%s" % CLANG_EXE,
         ),
         tool_path(
             name = "ld",

--- a/bazel/toolchains/clang_linux.bzl
+++ b/bazel/toolchains/clang_linux.bzl
@@ -1,0 +1,104 @@
+# NEW
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+# NEW
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+load("//bazel:install_clang.bzl", "CLANGPP_EXE", "LLVM_LINKER_EXE", "LLVM_AR_EXE")
+
+all_link_actions = [
+    # NEW
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+def _cc_toolchain_config_impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            # path = "/usr/bin/clang",
+            path = "/usr/bin/%s" % CLANGPP_EXE,
+        ),
+        tool_path(
+            name = "ld",
+            path = "/usr/bin/%s" % LLVM_LINKER_EXE,
+        ),
+        tool_path(
+            name = "ar",
+            path = "/usr/bin/%s" % LLVM_AR_EXE,
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/bin/bin/%s" % CLANGPP_EXE,
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/bin/false",
+        ),
+    ]
+
+    features = [
+        # NEW
+        feature(
+            name = "default_linker_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-lstdc++",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,  # NEW
+        cxx_builtin_include_directories = [
+            # "/usr/lib/llvm-9/lib/clang/9.0.1/include",
+            # "/usr/include",
+            # "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/",
+            # "/opt/homebrew/opt/llvm/include/c++/v1",
+            # "/opt/homebrew/opt/llvm/include",
+            # "/opt/homebrew/Cellar/llvm/16.0.6/lib/clang/16/include",
+        ],
+        toolchain_identifier = "local",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "x86_64",
+        target_libc = "unknown",
+        compiler = "clang",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+cc_clang_linux_toolchain_config = rule(
+    implementation = _cc_toolchain_config_impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)


### PR DESCRIPTION
Not ready yet:

~~- [ ] fixed clang version https://github.com/grailbio/bazel-toolchain/issues/207~~

Give up on `bazel-toolchain`, use my own repository_rule for installing `fixed version clang` on `macOS` and `Ubuntu`

- [x] let `rules_foreign_cc` use clang instead
- [x] let `rules_foreign_cc cmake` working properly 
- [x] build on macOS as well
- [x] ~~WIndows?  https://github.com/microsoft/vcpkg/issues/33507~~  use python .\Tools\Scripts\update-webkit-wincairo-libs.py
- [ ] Build JSC on Windows using CMake
- [ ] Call CMake using bazel