### PR TITLE
Allow moving the metadata part of `JSC::BuiltinExecutables::createExecutable` to a generator script

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1404,6 +1404,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
 
     runtime/JSModuleEnvironment.h
     runtime/JSModuleEnvironmentInlines.h
+
+    runtime/BuiltinExecutableMetadata.h
 )
 
 if(USE_INSPECTOR_SOCKET_SERVER)

--- a/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.cpp
@@ -34,5 +34,10 @@ UnlinkedFunctionExecutable* createBuiltinExecutable(VM& vm, const SourceCode& so
 {
     return BuiltinExecutables::createExecutable(vm, source, ident, implementationVisibility, kind, ability, NeedsClassFieldInitializer::No);
 }
-    
+
+UnlinkedFunctionExecutable* createBuiltinExecutable(VM& vm, const SourceCode& source, const Identifier& ident, ImplementationVisibility implementationVisibility, ConstructorKind kind, ConstructAbility ability, const BuiltinExecutableMetadata& metadata)
+{
+    return BuiltinExecutables::createExecutable(vm, source, ident, implementationVisibility, kind, ability, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None, metadata);
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h
@@ -30,9 +30,12 @@
 #include "ImplementationVisibility.h"
 #include "ParserModes.h"
 #include "SourceCode.h"
+#include "BuiltinExecutableMetadata.h"
 
 namespace JSC {
 
 JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
+JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, const BuiltinExecutableMetadata&);
+
 
 } // namespace JSC

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -37,6 +37,7 @@ namespace JSC {
 class UnlinkedFunctionExecutable;
 class Identifier;
 class VM;
+class BuiltinExecutableMetadata;
 
 #define BUILTIN_NAME_ONLY(name, functionName, overriddenName, length) name,
 enum class BuiltinCodeIndex {
@@ -61,7 +62,7 @@ SourceCode name##Source();
     UnlinkedFunctionExecutable* createDefaultConstructor(ConstructorKind, const Identifier& name, NeedsClassFieldInitializer, PrivateBrandRequirement);
 
     static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, NeedsClassFieldInitializer, PrivateBrandRequirement = PrivateBrandRequirement::None);
-
+    static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, NeedsClassFieldInitializer, PrivateBrandRequirement, const BuiltinExecutableMetadata&);
     void finalizeUnconditionally(CollectionScope);
 
 private:

--- a/Source/JavaScriptCore/builtins/BuiltinUtils.h
+++ b/Source/JavaScriptCore/builtins/BuiltinUtils.h
@@ -42,7 +42,10 @@ class Identifier;
 class SourceCode;
 class UnlinkedFunctionExecutable;
 class VM;
+class BuiltinExecutableMetadata;
 
 JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
+JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, const BuiltinExecutableMetadata&);
+
     
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/BuiltinExecutableMetadata.h
+++ b/Source/JavaScriptCore/runtime/BuiltinExecutableMetadata.h
@@ -1,0 +1,46 @@
+#pragma once
+
+namespace JSC {
+
+class BuiltinExecutableMetadata {
+public:
+    BuiltinExecutableMetadata(const unsigned char* data, unsigned length);
+    BuiltinExecutableMetadata() = default;
+    BuiltinExecutableMetadata(unsigned startColumn, unsigned endColumn, int functionKeywordStart, int functionNameStart, unsigned parametersStart, bool isInStrictContext, bool isArrowFunctionBodyExpression, bool isAsyncFunction, unsigned asyncOffset, unsigned parameterCount, unsigned lineCount, unsigned offsetOfLastNewline, unsigned positionBeforeLastNewlineLineStartOffset, unsigned closeBraceOffsetFromEnd)
+        : startColumn(startColumn)
+        , endColumn(endColumn)
+        , functionKeywordStart(functionKeywordStart)
+        , functionNameStart(functionNameStart)
+        , parametersStart(parametersStart)
+        , isInStrictContext(isInStrictContext)
+        , isArrowFunctionBodyExpression(isArrowFunctionBodyExpression)
+        , isAsyncFunction(isAsyncFunction)
+        , asyncOffset(asyncOffset)
+        , parameterCount(parameterCount)
+        , lineCount(lineCount)
+        , offsetOfLastNewline(offsetOfLastNewline)
+        , positionBeforeLastNewlineLineStartOffset(positionBeforeLastNewlineLineStartOffset)
+        , closeBraceOffsetFromEnd(closeBraceOffsetFromEnd)
+    {
+    }
+
+    unsigned startColumn;
+    unsigned endColumn;
+
+    int functionKeywordStart;
+    int functionNameStart;
+    unsigned parametersStart;
+    bool isInStrictContext;
+    bool isArrowFunctionBodyExpression;
+    bool isAsyncFunction;
+
+    unsigned asyncOffset;
+    unsigned parameterCount;
+
+    unsigned lineCount;
+    unsigned offsetOfLastNewline;
+    unsigned positionBeforeLastNewlineLineStartOffset;
+    unsigned closeBraceOffsetFromEnd;
+};
+
+} // namespace JSC


### PR DESCRIPTION
Fixes https://bugs.webkit.org/show_bug.cgi?id=193272

