### PR TITLE
windows: fix url handling issues

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -312,10 +312,6 @@ String URL::fileSystemPath() const
     if (UNLIKELY(unc_host.length() > 0)) {
         return makeString("\\\\"_s, unc_host, "\\"_s, decodeEscapeSequencesFromParsedURLForWindowsPath(path()));
     }
-    // It should be impossible to construct a file:// url without a host and not start with a slash.
-    // Doing `new URL("file://C:/hello")` parses to have path() = "/C:/hello"
-    // UNC paths will take advantage of this for the output, while regular paths will 
-    ASSERT(path().startsWith('/'));
     return decodeEscapeSequencesFromParsedURLForWindowsPath(path());
 #else
     return decodeEscapeSequencesFromParsedURL(path());

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -309,14 +309,14 @@ String URL::fileSystemPath() const
 #if OS(WINDOWS)
     // UNC paths look like '\\server\share\etc', but in a URL they look like 'file://server/share/etc'.
     auto unc_host = host();
-    if (UNLIKELY(unc_host)) {
+    if (UNLIKELY(unc_host.length() > 0)) {
         return makeString("\\\\"_s, unc_host, "\\"_s, decodeEscapeSequencesFromParsedURLForWindowsPath(path()));
     }
     // It should be impossible to construct a file:// url without a host and not start with a slash.
     // Doing `new URL("file://C:/hello")` parses to have path() = "/C:/hello"
     // UNC paths will take advantage of this for the output, while regular paths will 
     ASSERT(path().startsWith('/'));
-    return decodeEscapeSequencesFromParsedURLForWindowsPath(path().substring(1));
+    return decodeEscapeSequencesFromParsedURLForWindowsPath(path());
 #else
     return decodeEscapeSequencesFromParsedURL(path());
 #endif
@@ -1137,12 +1137,23 @@ URL URL::fakeURLWithRelativePart(StringView relativePart)
     return URL(makeString("webkit-fake-url://"_s, UUID::createVersion4(), '/', relativePart));
 }
 
+#if OS(WINDOWS)
+template <typename CharacterType>
+ALWAYS_INLINE bool isUNCLikePathImpl(CharacterType data) {
+    return (data[0] == '\\' || data[0] == '/') && (data[1] == '\\' || data[1] == '/');
+}
+ALWAYS_INLINE bool isUNCLikePath(StringView path)
+{
+    return path.length() > 2 && (path.is8Bit() ? isUNCLikePathImpl(path.characters8()) : isUNCLikePathImpl(path.characters16()));
+}
+#endif // OS(WINDOWS)
+
 URL URL::fileURLWithFileSystemPath(StringView path)
 {
 #if OS(WINDOWS)
     // Handle UNC paths on Windows. should result in file://server/share
-    if (path.startsWith("//"_s)) {
-        return URL(makeString("file://"_s, path.substring(2)));
+    if (isUNCLikePath(path)) {
+        return URL(makeString("file://"_s, escapePathWithoutCopying(path.substring(2))));
     }
 #endif
     return URL(makeString(


### PR DESCRIPTION
i mistake in my first attempt oops

before:

<img width="679" alt="image" src="https://github.com/oven-sh/WebKit/assets/24465214/3bb3340f-a006-4522-be25-01c1a5824192">

after:

<img width="646" alt="image" src="https://github.com/oven-sh/WebKit/assets/24465214/85bfd35b-4f5f-4aaf-b25d-e06fb171f025">

in bun i also un-skipped a bunch of these tests. we do not parse urls with backslashes in one specific which is the one todo test remaining. chrome does parse backslashes. i looked into this and it does seem to be a bug within webkit; since it is URL parser specific and the rest of my changes are not, i think it is best not to update this code now.