### PR TITLE
Fix CI bun-webkit-linux-arm64-debug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,12 @@ jobs:
           - runner: windows-latest
             build-type: Release
             arch: amd64
+            suffix: ""
+        include:
+          - runner: windows-latest
+            build-type: Debug
+            arch: amd64
+            suffix: debug
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
@@ -176,7 +182,7 @@ jobs:
           ./windows-release.ps1
       - uses: actions/upload-artifact@v3
         with:
-          name: bun-webkit-windows-${{ matrix.arch }}
+          name: bun-webkit-windows-${{ matrix.arch }}${{ matrix.suffix }}
           path: bun-webkit.tar.gz
 
   release:
@@ -242,6 +248,11 @@ jobs:
         with:
           name: bun-webkit-windows-amd64
           path: ${{runner.temp}}/bun-webkit-windows-amd64
+      - uses: actions/download-artifact@v3
+        with:
+          name: bun-webkit-windows-amd64-debug
+          name: bun-webkit-windows-amd64-debug
+          path: ${{runner.temp}}/bun-webkit-windows-amd64-debug
 
       - name: Rename files
         run: |
@@ -258,11 +269,11 @@ jobs:
           mv ${{runner.temp}}/bun-webkit-linux-arm64-lto/bun-webkit.tar.gz ${{runner.temp}}/bun-webkit-linux-arm64-lto.tar.gz
           mv ${{runner.temp}}/bun-webkit-linux-amd64-lto/bun-webkit.tar.gz ${{runner.temp}}/bun-webkit-linux-amd64-lto.tar.gz
           mv ${{runner.temp}}/bun-webkit-windows-amd64/bun-webkit.tar.gz ${{runner.temp}}/bun-webkit-windows-amd64.tar.gz
+          mv ${{runner.temp}}/bun-webkit-windows-amd64-debug/bun-webkit.tar.gz ${{runner.temp}}/bun-webkit-windows-amd64-debug.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v1
         id: release
         with:
-          prerelease: true
           generate_release_notes: true
           tag_name: "autobuild-${{github.sha}}"
           files: |
@@ -279,108 +290,4 @@ jobs:
             ${{runner.temp}}/bun-webkit-macos-arm64-lto.tar.gz
             ${{runner.temp}}/bun-webkit-macos-amd64-lto.tar.gz
             ${{runner.temp}}/bun-webkit-windows-amd64.tar.gz
-      - name: Canary
-        uses: softprops/action-gh-release@v1
-        with:
-          prerelease: true
-          generate_release_notes: true
-          tag_name: "canary"
-          files: |
-            ${{runner.temp}}/bun-webkit-linux-amd64.tar.gz
-            ${{runner.temp}}/bun-webkit-linux-arm64.tar.gz
-            ${{runner.temp}}/bun-webkit-macos-arm64.tar.gz
-            ${{runner.temp}}/bun-webkit-macos-amd64.tar.gz
-            ${{runner.temp}}/bun-webkit-linux-amd64-debug.tar.gz
-            ${{runner.temp}}/bun-webkit-linux-arm64-debug.tar.gz
-            ${{runner.temp}}/bun-webkit-macos-arm64-debug.tar.gz
-            ${{runner.temp}}/bun-webkit-macos-amd64-debug.tar.gz
-            ${{runner.temp}}/bun-webkit-linux-amd64-lto.tar.gz
-            ${{runner.temp}}/bun-webkit-linux-arm64-lto.tar.gz
-            ${{runner.temp}}/bun-webkit-macos-arm64-lto.tar.gz
-            ${{runner.temp}}/bun-webkit-macos-amd64-lto.tar.gz
-            ${{runner.temp}}/bun-webkit-windows-amd64.tar.gz
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16.x"
-          registry-url: "https://registry.npmjs.org"
-      - run: |
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-linux-amd64-lto.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-linux-arm64-lto.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-macos-arm64-lto.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-macos-amd64-lto.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-linux-amd64.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-linux-arm64.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-macos-arm64.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit
-          cd ${{runner.temp}}
-          tar -xzf bun-webkit-macos-amd64.tar.gz
-          cd bun-webkit
-          npm publish --tag next --access=public
-
-          rm -rf ${{runner.temp}}/bun-webkit-lto ${{runner.temp}}/bun-webkit ${{runner.temp}}/bun-webkit-debug
-          mkdir -p ${{runner.temp}}/bun-webkit-lto ${{runner.temp}}/bun-webkit ${{runner.temp}}/bun-webkit-debug
-
-          echo '{ "name": "bun-webkit", "version": "0.0.1-${{github.sha}}", "repository": "https://github.com/${{github.repository}}", "optionalDependencies": {"bun-webkit-linux-amd64": "0.0.1-${{github.sha}}", "bun-webkit-linux-arm64": "0.0.1-${{github.sha}}", "bun-webkit-macos-arm64": "0.0.1-${{github.sha}}", "bun-webkit-macos-amd64": "0.0.1-${{github.sha}}"} }' > ${{runner.temp}}/bun-webkit/package.json
-          echo '{ "name": "bun-webkit-lto", "version": "0.0.1-${{github.sha}}", "repository": "https://github.com/${{github.repository}}", "optionalDependencies": {"bun-webkit-linux-amd64-lto": "0.0.1-${{github.sha}}", "bun-webkit-linux-arm64-lto": "0.0.1-${{github.sha}}", "bun-webkit-macos-arm64-lto": "0.0.1-${{github.sha}}", "bun-webkit-macos-amd64-lto": "0.0.1-${{github.sha}}"} }' > ${{runner.temp}}/bun-webkit-lto/package.json
-          echo '{ "name": "bun-webkit-debug", "version": "0.0.1-${{github.sha}}", "repository": "https://github.com/${{github.repository}}", "config": {"bun-webkit-linux-amd64-debug": "${{ fromJSON(steps.release.outputs.assets)[0].browser_download_url }}", "bun-webkit-linux-arm64-debug": "${{ fromJSON(steps.release.outputs.assets)[1].browser_download_url }}", "bun-webkit-macos-arm64-debug": "${{ fromJSON(steps.release.outputs.assets)[2].browser_download_url }}", "bun-webkit-macos-amd64-debug": "${{ fromJSON(steps.release.outputs.assets)[3].browser_download_url }}"} }' > ${{runner.temp}}/bun-webkit-debug/package.json
-
-          echo "$README_TEXT" > ${{runner.temp}}/bun-webkit/README.md
-          echo "$README_TEXT" > ${{runner.temp}}/bun-webkit-lto/README.md
-          echo "$README_TEXT" > ${{runner.temp}}/bun-webkit-debug/README.md
-
-          cd ${{runner.temp}}/bun-webkit
-          npm publish --tag next --access=public
-
-          cd ${{runner.temp}}/bun-webkit-lto
-          npm publish --tag next --access=public
-
-          cd ${{runner.temp}}/bun-webkit-debug
-          npm publish --tag next --access=public
-
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          README_TEXT: |
-            # WebKit
-
-            [Bun](https://bun.sh) is a new all-in-one JavaScript runtime.
-
-            This is Bun's WebKit build. The optional dependencies of this package have prebuilt JavaScriptCore/WebKit static libraries.
-
-            The goal of this package is to simplify contributing to Bun. Instead of cloning and building WebKit yourself, you can use this package.
-
-            This version corresponds to #[${{github.sha}}](https://github.com/${{github.repository}}/commit/${{github.sha}}).
+            ${{runner.temp}}/bun-webkit-windows-amd64-debug.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,8 @@ jobs:
             CMAKE_BUILD_TYPE: "Debug"
           - lto_flag: ""
             label: bun-webkit-linux-arm64-debug
-            os: big-ubuntu
-            package_json_arch: "x64"
+            os: linux-arm64
+            package_json_arch: "arm64"
             CMAKE_BUILD_TYPE: "Debug"
           - lto_flag: "-flto='full'"
             label: bun-webkit-linux-arm64-lto

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ Source/ThirdParty/ANGLE/parsetab.py
 CMakeUserPresets.json
 
 bun-webkit-*
+bun-webkit


### PR DESCRIPTION
Fix CI file causing linux-arm64-debug builds to publish x64 builds

Fixes https://github.com/oven-sh/bun/issues/7487