### PR TITLE
Support typed arrays up to 512 GB

### DIFF
--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -38,9 +38,10 @@ namespace JSC {
 static_assert(sizeof(size_t) == sizeof(uint64_t));
 
 #if USE(BUN_JSC_ADDITIONS)
-// Allow up to 140 TB typed arrays in Bun
-// `maxPageCount` below must fit inside a UINT_MAX, and (64 KB / 1<<47) is just under that limit.
-#define MAX_ARRAY_BUFFER_SIZE (1ull << 47)
+// Allow up to 512 GB typed arrays in Bun
+// `maxPageCount` below must fit inside a UINT_MAX
+// The theoretical limit here is 47 bits, but making this number larger than necessary is a security risk
+#define MAX_ARRAY_BUFFER_SIZE (1ull << 39)
 #else
 #define MAX_ARRAY_BUFFER_SIZE (1ull << 32)
 #endif

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -36,7 +36,14 @@ namespace JSC {
 
 #if USE(LARGE_TYPED_ARRAYS)
 static_assert(sizeof(size_t) == sizeof(uint64_t));
+
+#if USE(BUN_JSC_ADDITIONS)
+// Allow up to 140 TB typed arrays in Bun
+// `maxPageCount` below must fit inside a UINT_MAX, and (64 KB / 1<<47) is just under that limit.
+#define MAX_ARRAY_BUFFER_SIZE (1ull << 47)
+#else
 #define MAX_ARRAY_BUFFER_SIZE (1ull << 32)
+#endif
 #else
 static_assert(sizeof(size_t) == sizeof(uint32_t));
 // Because we are using a size_t to store the size in bytes of array buffers, we cannot support 4GB on 32-bit platforms.


### PR DESCRIPTION
The current number is 4 GB.

128 TB or so is the theoretical max without causing other issues

512 GB is a middleground where most usecases for extremely large typed arrays (such as `mmap`) are covered 


