### PR TITLE
Add variable name to ReferenceError

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1193,6 +1193,7 @@ op :argument_count,
 op :check_tdz,
     args: {
         targetVirtualRegister: VirtualRegister,
+        identifier?: VirtualRegister,
     }
 
 op :new_array_with_spread,

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3127,9 +3127,14 @@ RegisterID* BytecodeGenerator::emitInstanceFieldInitializationIfNeeded(RegisterI
     return dst;
 }
 
+void BytecodeGenerator::emitTDZCheck(RegisterID* target, const Variable& variable)
+{
+    OpCheckTdz::emit(this, target, addConstantValue(addStringConstant(variable.ident())));
+}
+
 void BytecodeGenerator::emitTDZCheck(RegisterID* target)
 {
-    OpCheckTdz::emit(this, target);
+    OpCheckTdz::emit(this, target, addConstantValue(jsUndefined()));
 }
 
 bool BytecodeGenerator::needsTDZCheck(const Variable& variable)
@@ -3156,11 +3161,11 @@ void BytecodeGenerator::emitTDZCheckIfNecessary(const Variable& variable, Regist
 {
     if (needsTDZCheck(variable)) {
         if (target)
-            emitTDZCheck(target);
+            emitTDZCheck(target, variable);
         else {
             RELEASE_ASSERT(!variable.isLocal() && scope);
             RefPtr<RegisterID> result = emitGetFromScope(newTemporary(), scope, variable, DoNotThrowIfNotFound);
-            emitTDZCheck(result.get());
+            emitTDZCheck(result.get(), variable);
         }
     }
 }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -734,6 +734,7 @@ namespace JSC {
         RegisterID* emitCreateAsyncGenerator(RegisterID* dst, RegisterID* newTarget);
         RegisterID* emitInstanceFieldInitializationIfNeeded(RegisterID* dst, RegisterID* constructor, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
         void emitTDZCheck(RegisterID* target);
+        void emitTDZCheck(RegisterID* target, const Variable&);
         bool needsTDZCheck(const Variable&);
         void emitTDZCheckIfNecessary(const Variable&, RegisterID* target, RegisterID* scope);
         void liftTDZCheckIfPossible(const Variable&);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -277,7 +277,7 @@ RegisterID* ResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* 
     else {
         RefPtr<RegisterID> uncheckedResult = generator.newTemporary();
         generator.emitGetFromScope(uncheckedResult.get(), scope.get(), var, ThrowIfNotFound);
-        generator.emitTDZCheck(uncheckedResult.get());
+        generator.emitTDZCheck(uncheckedResult.get(), m_ident);
         generator.move(finalDest, uncheckedResult.get());
     }
     generator.emitProfileType(finalDest, var, m_position, m_position + m_ident.length());

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3873,7 +3873,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetDynamicVar, EncodedJSValue, (JSGlobalObject
             // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
             JSValue result = slot.getValue(globalObject, ident);
             if (result == jsTDZValue()) {
-                throwException(globalObject, throwScope, createTDZError(globalObject));
+                throwException(globalObject, throwScope, createTDZError(globalObject, ident));
                 return jsUndefined();
             }
             return result;
@@ -3898,7 +3898,7 @@ ALWAYS_INLINE static void putDynamicVar(JSGlobalObject* globalObject, VM& vm, JS
         PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
         JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
         if (slot.getValue(globalObject, ident) == jsTDZValue()) {
-            throwException(globalObject, throwScope, createTDZError(globalObject));
+            throwException(globalObject, throwScope, createTDZError(globalObject, ident));
             return;
         }
     }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1052,7 +1052,7 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
                     PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
                     JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
                     if (slot.getValue(globalObject, ident) == jsTDZValue())
-                        return throwException(globalObject, throwScope, createTDZError(globalObject));
+                        return throwException(globalObject, throwScope, createTDZError(globalObject, ident));
                     baseObject = scope;
                 }
             }

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -4141,7 +4141,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetFromScope, EncodedJSValue, (JSGlobalObject*
             // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
             result = slot.getValue(globalObject, ident);
             if (result == jsTDZValue()) {
-                throwException(globalObject, throwScope, createTDZError(globalObject));
+                throwException(globalObject, throwScope, createTDZError(globalObject, ident));
                 return jsUndefined();
             }
         }
@@ -4190,7 +4190,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutToScope, void, (JSGlobalObject* globalObjec
         PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
         JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
         if (slot.getValue(globalObject, ident) == jsTDZValue()) {
-            throwException(globalObject, throwScope, createTDZError(globalObject));
+            throwException(globalObject, throwScope, createTDZError(globalObject, ident));
             return;
         }
     }

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2303,7 +2303,7 @@ LLINT_SLOW_PATH_DECL(slow_path_get_from_scope)
             // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
             result = slot.getValue(globalObject, ident);
             if (result == jsTDZValue())
-                return throwException(globalObject, throwScope, createTDZError(globalObject));
+                return throwException(globalObject, throwScope, createTDZError(globalObject, ident));
         }
 
         CommonSlowPaths::tryCacheGetFromScopeGlobal(globalObject, codeBlock, vm, bytecode, scope, slot, ident);
@@ -2344,7 +2344,7 @@ LLINT_SLOW_PATH_DECL(slow_path_put_to_scope)
         PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
         JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
         if (slot.getValue(globalObject, ident) == jsTDZValue())
-            LLINT_THROW(createTDZError(globalObject));
+            LLINT_THROW(createTDZError(globalObject, ident));
     }
 
     if (metadata.m_getPutInfo.resolveMode() == ThrowIfNotFound && !hasProperty)

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -344,6 +344,15 @@ JSObject* createTDZError(JSGlobalObject* globalObject)
     return createReferenceError(globalObject, "Cannot access uninitialized variable."_s);
 }
 
+JSObject* createTDZError(JSGlobalObject* globalObject, const Identifier &ident)
+{
+    if (ident.isSymbol() || ident.isPrivateName() || ident.isEmpty()) {
+        return createTDZError(globalObject);
+    }
+
+    return createReferenceError(globalObject, makeString("Cannot access '"_s, ident.string(), "' before initialization."_s));
+}
+
 JSObject* createInvalidPrivateNameError(JSGlobalObject* globalObject)
 {
     return createTypeError(globalObject, "Cannot access invalid private field"_s, defaultSourceAppender, TypeNothing);

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.h
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.h
@@ -46,6 +46,7 @@ JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, JSValue, const String&,
 JS_EXPORT_PRIVATE JSObject* createStackOverflowError(JSGlobalObject*);
 JSObject* createUndefinedVariableError(JSGlobalObject*, const Identifier&);
 JSObject* createTDZError(JSGlobalObject*);
+JSObject* createTDZError(JSGlobalObject*, const Identifier&);
 JS_EXPORT_PRIVATE JSObject* createNotAnObjectError(JSGlobalObject*, JSValue);
 JSObject* createInvalidFunctionApplyParameterError(JSGlobalObject*, JSValue);
 JSObject* createInvalidInParameterError(JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -154,7 +154,7 @@ bool JSModuleNamespaceObject::getOwnPropertySlotCommon(JSGlobalObject* globalObj
         JSValue value = getValue(environment, exportEntry.localName, scopeOffset);
         // If the value is filled with TDZ value, throw a reference error.
         if (!value) {
-            throwVMError(globalObject, scope, createTDZError(globalObject));
+            throwVMError(globalObject, scope, createTDZError(globalObject, JSC::Identifier::fromUid(vm, propertyName.uid())));
             return false;
         }
 


### PR DESCRIPTION
After:
```js
1 | const fetch = await fetch("https://example.com");
                        ^
ReferenceError: Cannot access 'fetch' before initialization.
      at /Users/jarred/Code/bun/hey.js:1:21
```

Before:
```js
1 | const fetch = await fetch("https://example.com");
                        ^
ReferenceError: Cannot access uninitialized variable.
      at /Users/jarred/Code/bun/hey.js:1:21

```