### PR TITLE
handle exceptions in `ModuleProgramExecutable::create`

### DIFF
--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -91,11 +91,6 @@ Synchronousness JSModuleRecord::link(JSGlobalObject* globalObject, JSValue scrip
     EXCEPTION_ASSERT(!!scope.exception() == !executable);
     RETURN_IF_EXCEPTION(scope, Synchronousness::Sync);
 
-    if (!executable) {
-        throwSyntaxError(globalObject, scope);
-        return Synchronousness::Sync;
-    }
-
     instantiateDeclarations(globalObject, executable, scriptFetcher);
     RETURN_IF_EXCEPTION(scope, Synchronousness::Sync);
     m_moduleProgramExecutable.set(vm, this, executable);

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -89,10 +89,13 @@ Synchronousness JSModuleRecord::link(JSGlobalObject* globalObject, JSValue scrip
 
     ModuleProgramExecutable* executable = ModuleProgramExecutable::create(globalObject, sourceCode());
     EXCEPTION_ASSERT(!!scope.exception() == !executable);
+    RETURN_IF_EXCEPTION(scope, Synchronousness::Sync);
+
     if (!executable) {
         throwSyntaxError(globalObject, scope);
         return Synchronousness::Sync;
     }
+
     instantiateDeclarations(globalObject, executable, scriptFetcher);
     RETURN_IF_EXCEPTION(scope, Synchronousness::Sync);
     m_moduleProgramExecutable.set(vm, this, executable);

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
@@ -75,7 +75,9 @@ ModuleProgramExecutable* ModuleProgramExecutable::create(JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     ModuleProgramExecutable* executable = new (NotNull, allocateCell<ModuleProgramExecutable>(vm)) ModuleProgramExecutable(globalObject, source);
     executable->finishCreation(vm);
-    executable->getUnlinkedCodeBlock(globalObject); // This generates and binds unlinked code block.
+    // This generates and binds unlinked code block.
+    if (!executable->getUnlinkedCodeBlock(globalObject))
+        return nullptr;
     return executable;
 }
 


### PR DESCRIPTION
It's possible for `getUnlinkedCodeBlock` to throw an exception and return null. This change checks for this exception.

Will fix https://github.com/oven-sh/bun/issues/13572 when we bump webkit.