### PR TITLE
Prep for only parsing es modules once in jsc

### DIFF
--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -56,6 +56,9 @@ class UnlinkedFunctionCodeBlock;
         JSON,
         Synthetic,
         ImportMap,
+#if USE(BUN_JSC_ADDITIONS)
+        BunTranspiledModule,
+#endif
     };
 
     using BytecodeCacheGenerator = Function<RefPtr<CachedBytecode>()>;

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -390,9 +390,7 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
         }
 #if USE(BUN_JSC_ADDITIONS)
         case SourceProviderSourceType::BunTranspiledModule: {
-            EncodedJSValue result = Bun__analyzeTranspiledModule(globalObject, moduleKey, sourceCode, promise);
-            scope.release();
-            return result;
+            RELEASE_AND_RETURN(scope, Bun__analyzeTranspiledModule(globalObject, moduleKey, sourceCode, promise));
         }
 #endif
         default: {

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
@@ -36,7 +36,11 @@ ModuleProgramExecutable::ModuleProgramExecutable(JSGlobalObject* globalObject, c
     : Base(globalObject->vm().moduleProgramExecutableStructure.get(), globalObject->vm(), source, StrictModeLexicallyScopedFeature, DerivedContextType::None, false, false, EvalContextType::None, NoIntrinsic)
 {
     SourceProviderSourceType sourceType = source.provider()->sourceType();
-    ASSERT(sourceType == SourceProviderSourceType::Module || sourceType == SourceProviderSourceType::BunTranspiledModule);
+    ASSERT(sourceType == SourceProviderSourceType::Module
+    #if USE(BUN_JSC_ADDITIONS)
+    || sourceType == SourceProviderSourceType::BunTranspiledModule
+    #endif
+    );
     VM& vm = globalObject->vm();
     if (vm.typeProfiler() || vm.controlFlowProfiler())
         vm.functionHasExecutedCache()->insertUnexecutedRange(sourceID(), typeProfilingStartOffset(), typeProfilingEndOffset());

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
@@ -35,7 +35,8 @@ const ClassInfo ModuleProgramExecutable::s_info = { "ModuleProgramExecutable"_s,
 ModuleProgramExecutable::ModuleProgramExecutable(JSGlobalObject* globalObject, const SourceCode& source)
     : Base(globalObject->vm().moduleProgramExecutableStructure.get(), globalObject->vm(), source, StrictModeLexicallyScopedFeature, DerivedContextType::None, false, false, EvalContextType::None, NoIntrinsic)
 {
-    ASSERT(source.provider()->sourceType() == SourceProviderSourceType::Module);
+    SourceProviderSourceType sourceType = source.provider()->sourceType();
+    ASSERT(sourceType == SourceProviderSourceType::Module || sourceType == SourceProviderSourceType::BunTranspiledModule);
     VM& vm = globalObject->vm();
     if (vm.typeProfiler() || vm.controlFlowProfiler())
         vm.functionHasExecutedCache()->insertUnexecutedRange(sourceID(), typeProfilingStartOffset(), typeProfilingEndOffset());


### PR DESCRIPTION
Adds an extern function Bun__analyzeTranspiledModule that is used get the ModuleRecord for a module if it is of type BunTranspiledModule