### PR TITLE
Ignore some imports that are not found in typescript

### DIFF
--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -781,6 +781,9 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
         RETURN_IF_EXCEPTION(scope, nullptr);
         switch (resolution.type) {
         case Resolution::Type::NotFound:
+#if USE(BUN_JSC_ADDITIONS)
+            if(m_isTypeScript) break;
+#endif
             throwSyntaxError(globalObject, scope, makeString("Exported binding name '"_s, StringView(name.get()), "' is not found."_s));
             return nullptr;
 

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -89,7 +89,14 @@ public:
         Identifier localName;
     };
 
-    enum class ImportEntryType { Single, Namespace };
+    enum class ImportEntryType {
+        Single, 
+#if USE(BUN_JSC_ADDITIONS)
+        // If the corresponding export is not found, do not emit an error.
+        SingleTypeScript,
+#endif
+        Namespace,
+    };
     struct ImportEntry {
         ImportEntryType type;
         Identifier moduleRequest;
@@ -160,6 +167,8 @@ public:
     JS_EXPORT_PRIVATE JSValue evaluate(JSGlobalObject*, JSValue sentValue, JSValue resumeMode);
     WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
     WriteBarrier<Unknown> internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+
+    bool m_isTypeScript = false;
 
 protected:
     AbstractModuleRecord(VM&, Structure*, const Identifier&);

--- a/Source/JavaScriptCore/runtime/JSModuleEnvironment.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleEnvironment.cpp
@@ -99,7 +99,11 @@ void JSModuleEnvironment::getOwnSpecialPropertyNames(JSObject* cell, JSGlobalObj
     if (propertyNamesArray.includeStringProperties()) {
         for (const auto& pair : thisObject->moduleRecord()->importEntries()) {
             const AbstractModuleRecord::ImportEntry& importEntry = pair.value;
-            if (importEntry.type == AbstractModuleRecord::ImportEntryType::Single)
+            if (importEntry.type == AbstractModuleRecord::ImportEntryType::Single
+#if USE(BUN_JSC_ADDITIONS)
+                || importEntry.type == AbstractModuleRecord::ImportEntryType::SingleTypeScript
+#endif
+            )
                 propertyNamesArray.add(importEntry.localName);
         }
     }

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -140,6 +140,9 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
             RETURN_IF_EXCEPTION(scope, void());
             switch (resolution.type) {
             case Resolution::Type::NotFound: {
+#if USE(BUN_JSC_ADDITIONS)
+                if(m_isTypeScript) break;
+#endif
                 throwSyntaxError(globalObject, scope, makeString("export '"_s, StringView(exportEntry.exportName.impl()), "' not found in '"_s, StringView(exportEntry.moduleName.impl()), "'"_s));
                 return;
             }
@@ -191,11 +194,19 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
             break;
         }
 
+#if USE(BUN_JSC_ADDITIONS)
+        case AbstractModuleRecord::ImportEntryType::SingleTypeScript:
+#endif
         case AbstractModuleRecord::ImportEntryType::Single: {
             Resolution resolution = importedModule->resolveExport(globalObject, importEntry.importName);
             RETURN_IF_EXCEPTION(scope, void());
             switch (resolution.type) {
             case Resolution::Type::NotFound: {
+#if USE(BUN_JSC_ADDITIONS)
+                if(importEntry.type == AbstractModuleRecord::ImportEntryType::SingleTypeScript) {
+                    break;
+                }
+#endif
                 if (!(importEntry.localName.isNull() || importEntry.localName.isPrivateName() || importEntry.localName.isSymbol())) {
                     Resolution otherResolution = importedModule->resolveExport(globalObject, vm.propertyNames->defaultKeyword);
                     if (otherResolution.type == Resolution::Type::Resolved && otherResolution.localName == importEntry.localName) {


### PR DESCRIPTION
Ignore import not found / export not found errors if the in a typescript file or the import entry type is SingleTypeScript