### PR TITLE
Match node's error.stack behaviour

### DIFF
--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -281,7 +281,7 @@ String ErrorInstance::sanitizedNameString(JSGlobalObject* globalObject)
     }
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (!nameValue || !nameValue.isPrimitive())
+    if (!nameValue || !nameValue.isPrimitive() || nameValue.isUndefined())
         return "Error"_s;
     RELEASE_AND_RETURN(scope, nameValue.toWTFString(globalObject));
 }


### PR DESCRIPTION
```js
const util = require("util");

const ent = {};
for(const val of [404, 0, 0n, null, undefined, false, "abc"]) {
    const err = new RangeError("foo");
    err.name = val;
    ent[""+val] = err.stack.split("\n")[0];
}
console.table(ent);
```

```
node:
┌───────────┬──────────────┐
│ (index)   │ Values       │
├───────────┼──────────────┤
│ 0         │ '0: foo'     │
│ 404       │ '404: foo'   │
│ null      │ 'null: foo'  │
│ undefined │ 'Error: foo' │
│ false     │ 'false: foo' │
│ abc       │ 'abc: foo'   │
└───────────┴──────────────┘
bun (before):
┌───────────┬────────────────┐
│           │ Values         │
├───────────┼────────────────┤
│         0 │ 0: foo         │
│       404 │ 404: foo       │
│      null │ null: foo      │
│ undefined │ undefined: foo │
│     false │ false: foo     │
│       abc │ abc: foo       │
└───────────┴────────────────┘
bun (after):
┌───────────┬────────────┐
│           │ Values     │
├───────────┼────────────┤
│         0 │ 0: foo     │
│       404 │ 404: foo   │
│      null │ null: foo  │
│ undefined │ Error: foo │
│     false │ false: foo │
│       abc │ abc: foo   │
└───────────┴────────────┘
```

Fixes `util.inspect()` when the name property on the error is set to undefined

Alternative: keep a local copy of the function in bun's code