### PR TITLE
Do nothing instead of asserting `RunLoop::wakeUp` is never reached

### DIFF
--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -92,7 +92,8 @@ void RunLoop::stop()
 
 void RunLoop::wakeUp()
 {
-    ASSERT_NOT_REACHED();
+    // Do nothing. This means that JSRunLoopTimer::Manager::PerVMData's RunLoop::Timer leaks instead
+    // of being freed.
 }
 
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode mode)


### PR DESCRIPTION
This means that `JSRunLoopTimer::Manager::PerVMData`'s `RunLoop::Timer` leaks instead of being freed, because the RunLoop is meant to be used to free this timer on the same thread it's fired on. But there's only one of these per VM so this leak would only matter using Workers, and those already leak memory anyway.