### PR TITLE
Use either BUN_EVENT_LOOP or GENERIC_EVENT_LOOP RunLoop implementation

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -204,8 +204,9 @@ public:
 #endif
 
         class ScheduledTask;
-        // TODO avoid init-ing this in BUN_EVENT_LOOP?
+#if USE(GENERIC_EVENT_LOOP)
         Ref<ScheduledTask> m_scheduledTask;
+#endif
 #endif
 #if USE(BUN_EVENT_LOOP)
         // These functions will be defined in RunLoopGeneric.cpp.
@@ -221,10 +222,10 @@ public:
         bool isActiveGeneric() const;
         Seconds secondsUntilFireGeneric() const;
 
-        inline Kind kind() const { return m_zigTimer ? Kind::Bun : Kind::Generic; }
+        inline Kind kind() const { return std::holds_alternative<Bun__WTFTimer*>(m_impl) ? Kind::Bun : Kind::Generic; }
 
-        // Null if we are not on a Bun JS thread
-        Bun__WTFTimer* const m_zigTimer;
+        // Bun__WTFTimer* for Bun implementation, Ref<ScheduledTask> for generic implementation
+        std::variant<Ref<ScheduledTask>, Bun__WTFTimer*> m_impl;
 #endif
     };
 

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -54,7 +54,7 @@
 #include <wtf/glib/GRefPtr.h>
 #endif
 
-#if USE(GENERIC_EVENT_LOOP)
+#if USE(GENERIC_EVENT_LOOP) || USE(BUN_EVENT_LOOP)
 #include <wtf/RedBlackTree.h>
 #endif
 
@@ -76,6 +76,22 @@ using RunLoopMode = unsigned;
 
 // Classes that offer Timers should be ref-counted of CanMakeCheckedPtr. Please do not add new exceptions.
 template<typename T> struct IsDeprecatedTimerSmartPointerException : std::false_type { };
+
+// WTF::RunLoop is designed to have only one implementation compiled in, depending on build
+// configuration. Bun would like to use either the implementation for GENERIC_EVENT_LOOP, on threads
+// that do not have a virtual machine (because these threads don't have a Bun event loop), or a Bun-
+// specific implementation that stubs almost all functionality except that needed for JSRunLoopTimer
+// (we integrate those timers into our event loop so that we do GC work at the times JSC wants to).
+// RunLoop has some fields that always exist, and some fields that are enabled depending on which
+// kind of RunLoop is being used. Our solution is to, when USE(BUN_EVENT_LOOP) is true, move all the
+// fields specific to GENERIC_EVENT_LOOP into a separate class (RunLoop::RunLoopGenericState), and
+// then give RunLoop a std::optional of that class. When a RunLoop is created, if there is a Bun VM
+// on its thread, we use the stub implementation; otherwise, we initialize m_genericState and use
+// those functions.
+//
+// Since RunLoopGeneric.cpp is not compiled in when building for Bun, we #include it in RunLoop.cpp
+// and use some #defines to make it define member functions of RunLoop::RunLoopGenericState instead
+// of RunLoop.
 
 class WTF_CAPABILITY("is current") RunLoop final : public GuaranteedSerialFunctionDispatcher {
     WTF_MAKE_NONCOPYABLE(RunLoop);
@@ -131,6 +147,10 @@ public:
     static void registerRunLoopMessageWindowClass();
 #endif
 
+#if USE(BUN_EVENT_LOOP)
+    enum class Kind { Generic, Bun };
+#endif
+
     class TimerBase {
         friend class RunLoop;
     public:
@@ -173,14 +193,32 @@ public:
         GRefPtr<GSource> m_source;
         bool m_isRepeating { false };
         Seconds m_interval { 0 };
-#elif USE(GENERIC_EVENT_LOOP)
+#elif USE(GENERIC_EVENT_LOOP) || USE(BUN_EVENT_LOOP)
+#if USE(BUN_EVENT_LOOP)
+        bool isActiveWithLock() const;
+        void stopWithLock();
+#else
         bool isActiveWithLock() const WTF_REQUIRES_LOCK(m_runLoop->m_loopLock);
         void stopWithLock() WTF_REQUIRES_LOCK(m_runLoop->m_loopLock);
+#endif
 
         class ScheduledTask;
         Ref<ScheduledTask> m_scheduledTask;
-#elif USE(BUN_EVENT_LOOP)
-        Bun__WTFTimer* m_zigTimer;
+#endif
+#if USE(BUN_EVENT_LOOP)
+        // These functions will be defined in RunLoopGeneric.cpp.
+        // RunLoopBun.cpp defines non-`Generic` versions which choose which implementation to use
+        // based on m_isGenericTimer.
+        void destructGeneric();
+        void startGeneric(Seconds interval, bool repeat);
+        void stopGeneric();
+        bool isActiveGeneric() const;
+        Seconds secondsUntilFireGeneric() const;
+
+        inline Kind kind() const { return m_zigTimer ? Kind::Bun : Kind::Generic; }
+
+        // Null if we are not on a Bun JS thread
+        Bun__WTFTimer* const m_zigTimer;
 #endif
     };
 
@@ -285,10 +323,29 @@ private:
     Vector<GRefPtr<GMainLoop>> m_mainLoops;
     GRefPtr<GSource> m_source;
     WeakHashSet<Observer> m_observers;
-#elif USE(GENERIC_EVENT_LOOP)
+#elif USE(GENERIC_EVENT_LOOP) || USE(BUN_EVENT_LOOP)
+#if USE(BUN_EVENT_LOOP)
+class RunLoopGenericState {
+public:
+    RunLoopGenericState(RunLoop& parent);
+    ~RunLoopGenericState();
+    WTF_MAKE_NONCOPYABLE(RunLoopGenericState);
+    using CycleResult = ::WTF::RunLoop::CycleResult;
+    friend class ::WTF::RunLoop;
+private:
+    void scheduleWithLock(TimerBase::ScheduledTask&);
+    void unscheduleWithLock(TimerBase::ScheduledTask&);
+    void wakeUpWithLock();
+    void wakeUp();
+    void stop();
+    CycleResult static cycle(RunLoopMode = DefaultRunLoopMode);
+
+    RunLoop& m_parent;
+#else
     void scheduleWithLock(TimerBase::ScheduledTask&) WTF_REQUIRES_LOCK(m_loopLock);
     void unscheduleWithLock(TimerBase::ScheduledTask&) WTF_REQUIRES_LOCK(m_loopLock);
     void wakeUpWithLock() WTF_REQUIRES_LOCK(m_loopLock);
+#endif
 
     enum class RunMode {
         Iterate,
@@ -311,10 +368,21 @@ private:
     Vector<Status*> m_mainLoops;
     bool m_shutdown { false };
     bool m_pendingTasks { false };
+    Function<void()> m_wakeUpCallback;
+#if USE(BUN_EVENT_LOOP)
+};
+#endif
 #endif
 
-#if USE(GENERIC_EVENT_LOOP) || USE(WINDOWS_EVENT_LOOP)
+// Bun moves this field to RunLoopGenericState
+#if !USE(BUN_EVENT_LOOP) && (USE(GENERIC_EVENT_LOOP) || USE(WINDOWS_EVENT_LOOP))
     Function<void()> m_wakeUpCallback;
+#endif
+
+#if USE(BUN_EVENT_LOOP)
+    std::optional<RunLoopGenericState> m_genericState;
+
+    inline Kind kind() const { return m_genericState ? Kind::Generic : Kind::Bun; }
 #endif
 };
 

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -150,6 +150,7 @@ public:
 
 #if USE(BUN_EVENT_LOOP)
     enum class Kind { Generic, Bun };
+    WTF_EXPORT_PRIVATE Kind kind() const { return m_genericState ? Kind::Generic : Kind::Bun; }
 #endif
 
     class TimerBase {
@@ -400,8 +401,6 @@ private:
 #if USE(BUN_EVENT_LOOP)
     // nullopt if this run loop uses the Bun implementation
     std::optional<RunLoopGenericState> m_genericState;
-
-    inline Kind kind() const { return m_genericState ? Kind::Generic : Kind::Bun; }
 #endif
 };
 

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -54,6 +54,7 @@
 #include <wtf/glib/GRefPtr.h>
 #endif
 
+// BUN_EVENT_LOOP ends up compiling much of the generic code too, so we need this include
 #if USE(GENERIC_EVENT_LOOP) || USE(BUN_EVENT_LOOP)
 #include <wtf/RedBlackTree.h>
 #endif
@@ -195,20 +196,25 @@ public:
         Seconds m_interval { 0 };
 #elif USE(GENERIC_EVENT_LOOP) || USE(BUN_EVENT_LOOP)
 #if USE(BUN_EVENT_LOOP)
-        bool isActiveWithLock() const;
-        void stopWithLock();
+        bool isActiveWithLock() const WTF_REQUIRES_LOCK(m_runLoop->m_genericState->m_loopLock);
+        void stopWithLock() WTF_REQUIRES_LOCK(m_runLoop->m_genericState->m_loopLock);
 #else
         bool isActiveWithLock() const WTF_REQUIRES_LOCK(m_runLoop->m_loopLock);
         void stopWithLock() WTF_REQUIRES_LOCK(m_runLoop->m_loopLock);
 #endif
 
         class ScheduledTask;
+        // TODO avoid init-ing this in BUN_EVENT_LOOP?
         Ref<ScheduledTask> m_scheduledTask;
 #endif
 #if USE(BUN_EVENT_LOOP)
         // These functions will be defined in RunLoopGeneric.cpp.
         // RunLoopBun.cpp defines non-`Generic` versions which choose which implementation to use
         // based on m_isGenericTimer.
+        // I could have also done something like RunLoopGenericState, and moved the Generic-specific
+        // fields into another class, but since there are so few TimerBase member functions and
+        // fields I decided it would be less intrusive to rename the functions and include both the
+        // Generic field and the Bun field.
         void destructGeneric();
         void startGeneric(Seconds interval, bool repeat);
         void stopGeneric();
@@ -325,6 +331,8 @@ private:
     WeakHashSet<Observer> m_observers;
 #elif USE(GENERIC_EVENT_LOOP) || USE(BUN_EVENT_LOOP)
 #if USE(BUN_EVENT_LOOP)
+    // Here we make these fields be in their own class rather than existing on RunLoop.
+    // This is so RunLoop can wrap it all in an std::optional.
 class RunLoopGenericState {
 public:
     RunLoopGenericState(RunLoop& parent);
@@ -333,13 +341,18 @@ public:
     using CycleResult = ::WTF::RunLoop::CycleResult;
     friend class ::WTF::RunLoop;
 private:
-    void scheduleWithLock(TimerBase::ScheduledTask&);
-    void unscheduleWithLock(TimerBase::ScheduledTask&);
-    void wakeUpWithLock();
+    // The member function definitions in RunLoopGeneric.cpp will go on this class instead of on
+    // RunLoop, so we need declarations here.
+    void scheduleWithLock(TimerBase::ScheduledTask&) WTF_REQUIRES_LOCK(m_loopLock);
+    void unscheduleWithLock(TimerBase::ScheduledTask&) WTF_REQUIRES_LOCK(m_loopLock);
+    void wakeUpWithLock() WTF_REQUIRES_LOCK(m_loopLock);
     void wakeUp();
     void stop();
     CycleResult static cycle(RunLoopMode = DefaultRunLoopMode);
 
+    // Some of the above member functions need to call RunLoop member functions, and they can't call
+    // them directly anymore since they are not on the same class. So the RunLoopGenericState needs
+    // access to the RunLoop containing it.
     RunLoop& m_parent;
 #else
     void scheduleWithLock(TimerBase::ScheduledTask&) WTF_REQUIRES_LOCK(m_loopLock);
@@ -368,8 +381,12 @@ private:
     Vector<Status*> m_mainLoops;
     bool m_shutdown { false };
     bool m_pendingTasks { false };
-    Function<void()> m_wakeUpCallback;
 #if USE(BUN_EVENT_LOOP)
+    // This field is normally defined separately form the main `#if USE(GENERIC_EVENT_LOOP)`,
+    // because it also exists on Windows. So we have to explicitly move it up into
+    // RunLoopGenericState.
+    Function<void()> m_wakeUpCallback;
+    // Close the RunLoopGenericState class
 };
 #endif
 #endif
@@ -380,6 +397,7 @@ private:
 #endif
 
 #if USE(BUN_EVENT_LOOP)
+    // nullopt if this run loop uses the Bun implementation
     std::optional<RunLoopGenericState> m_genericState;
 
     inline Kind kind() const { return m_genericState ? Kind::Generic : Kind::Bun; }

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -28,6 +28,14 @@ extern "C" __attribute__((weak)) bool Bun__thisThreadHasVM();
 // works when Bun's event loop is not active.
 bool Bun__thisThreadHasVM()
 {
+    // Bun should override this function, so if we reach here then all the WTFTimer functions should
+    // not be defined
+    ASSERT(!WTFTimer__create);
+    ASSERT(!WTFTimer__update);
+    ASSERT(!WTFTimer__deinit);
+    ASSERT(!WTFTimer__isActive);
+    ASSERT(!WTFTimer__secondsUntilTimer);
+    ASSERT(!WTFTimer__cancel);
     return false;
 }
 

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -10,6 +10,8 @@
 #error RunLoop was not undef'd
 #elif defined(m_runLoop)
 #error m_runLoop was not undef'd
+#elif defined(m_scheduledTask)
+#error m_scheduledTask was not undef'd
 #endif
 
 namespace WTF {
@@ -42,12 +44,18 @@ bool Bun__thisThreadHasVM()
 
 RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& loop)
     : m_runLoop(WTFMove(loop))
-    , m_scheduledTask(ScheduledTask::create(*this))
-    // check if the zig function is actually available (it won't be in JSC shell, since that doesn't
-    // link Bun's zig code)
-    , m_zigTimer(Bun__thisThreadHasVM() ? WTFTimer__create(this) : nullptr)
+    // We need to init this here since there's no default constructor. We init with a nullptr
+    // WTFTimer. The body of the constructor always initializes it with a proper value.
+    , m_impl(nullptr)
 {
-    ASSERT(kind() == m_runLoop->kind());
+    switch (m_runLoop->kind()) {
+    case Kind::Generic:
+        m_impl.emplace<Ref<ScheduledTask>>(ScheduledTask::create(*this));
+        break;
+    case Kind::Bun:
+        m_impl.emplace<Bun__WTFTimer*>(WTFTimer__create(this));
+        break;
+    }
 }
 
 // Bun might start a JSC::VM without intending to create a Timer.
@@ -61,7 +69,7 @@ RunLoop::TimerBase::~TimerBase()
         destructGeneric();
         break;
     case Kind::Bun:
-        WTFTimer__deinit(m_zigTimer);
+        WTFTimer__deinit(std::get<Bun__WTFTimer*>(m_impl));
         break;
     }
 }
@@ -72,7 +80,7 @@ void RunLoop::TimerBase::stop()
     case Kind::Generic:
         return stopGeneric();
     case Kind::Bun:
-        return WTFTimer__cancel(m_zigTimer);
+        return WTFTimer__cancel(std::get<Bun__WTFTimer*>(m_impl));
     }
 }
 
@@ -82,7 +90,7 @@ bool RunLoop::TimerBase::isActive() const
     case Kind::Generic:
         return isActiveGeneric();
     case Kind::Bun:
-        return WTFTimer__isActive(m_zigTimer);
+        return WTFTimer__isActive(std::get<Bun__WTFTimer*>(m_impl));
     }
 }
 
@@ -92,7 +100,7 @@ Seconds RunLoop::TimerBase::secondsUntilFire() const
     case Kind::Generic:
         return secondsUntilFireGeneric();
     case Kind::Bun:
-        return Seconds(WTFTimer__secondsUntilTimer(m_zigTimer));
+        return Seconds(WTFTimer__secondsUntilTimer(std::get<Bun__WTFTimer*>(m_impl)));
     }
 }
 
@@ -102,7 +110,7 @@ void RunLoop::TimerBase::start(Seconds interval, bool repeat)
     case Kind::Generic:
         return startGeneric(interval, repeat);
     case Kind::Bun:
-        return WTFTimer__update(m_zigTimer, interval.value(), repeat);
+        return WTFTimer__update(std::get<Bun__WTFTimer*>(m_impl), interval.value(), repeat);
     }
 }
 

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -46,6 +46,7 @@ RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& loop)
     // link Bun's zig code)
     , m_zigTimer(Bun__thisThreadHasVM() ? WTFTimer__create(this) : nullptr)
 {
+    ASSERT(kind() == m_runLoop->kind());
 }
 
 // Bun might start a JSC::VM without intending to create a Timer.
@@ -113,7 +114,13 @@ extern "C" void WTFTimer__fire(RunLoop::TimerBase* timer)
 
 RunLoop::RunLoop()
 {
-    if (!Bun__thisThreadHasVM()) {
+    bool useGeneric = WTFTimer__create
+        // Bun function is defined, so we're in Bun, and the main Bun thread should always use the
+        // Bun RunLoop even though it's created when the VM doesn't exist yet
+        ? !(isMainThread() || Bun__thisThreadHasVM())
+        // We're not Bun
+        : true;
+    if (useGeneric) {
         m_genericState.emplace(*this);
     } else {
         // these functions should all be defined if we're in Bun

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -126,19 +126,25 @@ RunLoop::~RunLoop()
 
 void RunLoop::run()
 {
-    if (RunLoop::current().m_genericState) {
+    switch (RunLoop::current().kind()) {
+    case Kind::Generic:
         // matches RunLoopGeneric implementation
         RunLoop::current().m_genericState->runImpl(RunLoopGenericState::RunMode::Drain);
-    } else {
+        return;
+    case Kind::Bun:
+        // Our event loop should not call this function
         ASSERT_NOT_REACHED();
     }
 }
 
 void RunLoop::stop()
 {
-    if (m_genericState) {
+    switch (kind()) {
+    case Kind::Generic:
         m_genericState->stop();
-    } else {
+        return;
+    case Kind::Bun:
+        // Our event loop should not call this function
         ASSERT_NOT_REACHED();
     }
 }
@@ -151,11 +157,13 @@ void RunLoop::wakeUp()
 
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
-    if (RunLoop::current().m_genericState) {
+    switch (RunLoop::current().kind()) {
+    case Kind::Generic:
         // matches RunLoopGeneric implementation
         RunLoop::current().m_genericState->runImpl(RunLoopGenericState::RunMode::Iterate);
         return CycleResult::Continue;
-    } else {
+    case Kind::Bun:
+        // Our event loop should not call this function
         ASSERT_NOT_REACHED();
         return RunLoop::CycleResult::Stop;
     }

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -1,6 +1,17 @@
 #include "config.h"
 #include <wtf/RunLoop.h>
 
+// We need the definition of RunLoop::TimerBase::ScheduledTask, as well as the definitions of
+// RunLoopGeneric member functions (which we redefine to be on RunLoopGenericState instead)
+#include "../generic/RunLoopGeneric.cpp"
+
+// Ensure we cleaned up the mess in RunLoopGeneric.cpp
+#if defined(RunLoop)
+#error RunLoop was not undef'd
+#elif defined(m_runLoop)
+#error m_runLoop was not undef'd
+#endif
+
 namespace WTF {
 
 // Functions exported by Timer.zig
@@ -11,11 +22,21 @@ extern "C" __attribute__((weak)) bool WTFTimer__isActive(const RunLoop::TimerBas
 extern "C" __attribute__((weak)) double WTFTimer__secondsUntilTimer(const RunLoop::TimerBase::Bun__WTFTimer*);
 extern "C" __attribute__((weak)) void WTFTimer__cancel(RunLoop::TimerBase::Bun__WTFTimer*);
 
+extern "C" __attribute__((weak)) bool Bun__thisThreadHasVM();
+
+// Default definition for the JSC shell. Returning false will make us use a RunLoopGeneric which
+// works when Bun's event loop is not active.
+bool Bun__thisThreadHasVM()
+{
+    return false;
+}
+
 RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& loop)
     : m_runLoop(WTFMove(loop))
+    , m_scheduledTask(ScheduledTask::create(*this))
     // check if the zig function is actually available (it won't be in JSC shell, since that doesn't
     // link Bun's zig code)
-    , m_zigTimer(&WTFTimer__create ? WTFTimer__create(this) : nullptr)
+    , m_zigTimer(Bun__thisThreadHasVM() ? WTFTimer__create(this) : nullptr)
 {
 }
 
@@ -25,43 +46,53 @@ RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& loop)
 
 RunLoop::TimerBase::~TimerBase()
 {
-    if (&WTFTimer__deinit) {
-        if (m_zigTimer)
-            WTFTimer__deinit(m_zigTimer);
+    switch (kind()) {
+    case Kind::Generic:
+        destructGeneric();
+        break;
+    case Kind::Bun:
+        WTFTimer__deinit(m_zigTimer);
+        break;
     }
 }
 
 void RunLoop::TimerBase::stop()
 {
-    if (&WTFTimer__cancel) {
-        if (m_zigTimer)
-            WTFTimer__cancel(m_zigTimer);
+    switch (kind()) {
+    case Kind::Generic:
+        return stopGeneric();
+    case Kind::Bun:
+        return WTFTimer__cancel(m_zigTimer);
     }
 }
 
 bool RunLoop::TimerBase::isActive() const
 {
-    if (&WTFTimer__isActive) {
-        if (m_zigTimer)
-            return WTFTimer__isActive(m_zigTimer);
+    switch (kind()) {
+    case Kind::Generic:
+        return isActiveGeneric();
+    case Kind::Bun:
+        return WTFTimer__isActive(m_zigTimer);
     }
-    return false;
 }
 
 Seconds RunLoop::TimerBase::secondsUntilFire() const
 {
-    if (&WTFTimer__secondsUntilTimer) {
-        if (m_zigTimer)
-            return Seconds(WTFTimer__secondsUntilTimer(m_zigTimer));
+    switch (kind()) {
+    case Kind::Generic:
+        return secondsUntilFireGeneric();
+    case Kind::Bun:
+        return Seconds(WTFTimer__secondsUntilTimer(m_zigTimer));
     }
-    return -1.0_s;
 }
 
 void RunLoop::TimerBase::start(Seconds interval, bool repeat)
 {
-    if (&WTFTimer__update) {
-        if (m_zigTimer)
-            WTFTimer__update(m_zigTimer, interval.value(), repeat);
+    switch (kind()) {
+    case Kind::Generic:
+        return startGeneric(interval, repeat);
+    case Kind::Bun:
+        return WTFTimer__update(m_zigTimer, interval.value(), repeat);
     }
 }
 
@@ -74,20 +105,42 @@ extern "C" void WTFTimer__fire(RunLoop::TimerBase* timer)
 
 RunLoop::RunLoop()
 {
+    if (!Bun__thisThreadHasVM()) {
+        m_genericState.emplace(*this);
+    } else {
+        // these functions should all be defined if we're in Bun
+        ASSERT(WTFTimer__create);
+        ASSERT(WTFTimer__update);
+        ASSERT(WTFTimer__deinit);
+        ASSERT(WTFTimer__isActive);
+        ASSERT(WTFTimer__secondsUntilTimer);
+        ASSERT(WTFTimer__cancel);
+    }
 }
 
 RunLoop::~RunLoop()
 {
+    // if m_genericState has a value, ~RunLoopGenericState() will be called, so we don't need
+    // to do anything else here
 }
 
 void RunLoop::run()
 {
-    ASSERT_NOT_REACHED();
+    if (RunLoop::current().m_genericState) {
+        // matches RunLoopGeneric implementation
+        RunLoop::current().m_genericState->runImpl(RunLoopGenericState::RunMode::Drain);
+    } else {
+        ASSERT_NOT_REACHED();
+    }
 }
 
 void RunLoop::stop()
 {
-    ASSERT_NOT_REACHED();
+    if (m_genericState) {
+        m_genericState->stop();
+    } else {
+        ASSERT_NOT_REACHED();
+    }
 }
 
 void RunLoop::wakeUp()
@@ -96,11 +149,16 @@ void RunLoop::wakeUp()
     // of being freed.
 }
 
-RunLoop::CycleResult RunLoop::cycle(RunLoopMode mode)
+RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
-    (void)mode;
-    ASSERT_NOT_REACHED();
-    return RunLoop::CycleResult::Stop;
+    if (RunLoop::current().m_genericState) {
+        // matches RunLoopGeneric implementation
+        RunLoop::current().m_genericState->runImpl(RunLoopGenericState::RunMode::Iterate);
+        return CycleResult::Continue;
+    } else {
+        ASSERT_NOT_REACHED();
+        return RunLoop::CycleResult::Stop;
+    }
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -22,14 +22,15 @@ extern "C" __attribute__((weak)) bool WTFTimer__isActive(const RunLoop::TimerBas
 extern "C" __attribute__((weak)) double WTFTimer__secondsUntilTimer(const RunLoop::TimerBase::Bun__WTFTimer*);
 extern "C" __attribute__((weak)) void WTFTimer__cancel(RunLoop::TimerBase::Bun__WTFTimer*);
 
+// Weak, so that Bun can override it
 extern "C" __attribute__((weak)) bool Bun__thisThreadHasVM();
 
 // Default definition for the JSC shell. Returning false will make us use a RunLoopGeneric which
 // works when Bun's event loop is not active.
 bool Bun__thisThreadHasVM()
 {
-    // Bun should override this function, so if we reach here then all the WTFTimer functions should
-    // not be defined
+    // Bun should override this function, so we should only reach here if we are *not* running in
+    // Bun in which case all the WTFTimer functions should not be defined
     ASSERT(!WTFTimer__create);
     ASSERT(!WTFTimer__update);
     ASSERT(!WTFTimer__deinit);

--- a/Source/WTF/wtf/bun/RunLoopBun.cpp
+++ b/Source/WTF/wtf/bun/RunLoopBun.cpp
@@ -166,8 +166,14 @@ void RunLoop::stop()
 
 void RunLoop::wakeUp()
 {
-    // Do nothing. This means that JSRunLoopTimer::Manager::PerVMData's RunLoop::Timer leaks instead
-    // of being freed.
+    switch (kind()) {
+    case Kind::Generic:
+        m_genericState->wakeUp();
+        return;
+    case Kind::Bun:
+        // Do nothing. This means that JSRunLoopTimer::Manager::PerVMData's RunLoop::Timer leaks instead
+        // of being freed.
+    }
 }
 
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -346,6 +346,8 @@ void RunLoop::unscheduleWithLock(TimerBase::ScheduledTask& task)
 // them access m_genericState (this is undefined behavior if m_genericState is nullopt, but none
 // of these functions should even get called if the run loop is not the generic implementation).
 #define m_runLoop (m_runLoop->m_genericState)
+// And m_scheduledTask needs to be accessed via the std::variant on TimerBase
+#define m_scheduledTask (std::get<Ref<ScheduledTask>>(m_impl))
 #endif
 
 // Since RunLoop does not own the registered TimerBase,
@@ -429,6 +431,7 @@ Seconds RunLoop::TimerBase::secondsUntilFire() const
 
 #if USE(BUN_EVENT_LOOP)
 #undef m_runLoop
+#undef m_scheduledTask
 #endif
 
 } // namespace WTF

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -120,11 +120,20 @@ private:
     bool m_isScheduled { };
 };
 
+#if USE(BUN_EVENT_LOOP)
+RunLoop::RunLoopGenericState::RunLoopGenericState(RunLoop& parent)
+    : m_parent(parent)
+#else
 RunLoop::RunLoop()
+#endif
 {
 }
 
+#if USE(BUN_EVENT_LOOP)
+RunLoop::RunLoopGenericState::~RunLoopGenericState()
+#else
 RunLoop::~RunLoop()
+#endif
 {
     Locker locker { m_loopLock };
     m_shutdown = true;
@@ -134,6 +143,10 @@ RunLoop::~RunLoop()
     if (!m_mainLoops.isEmpty())
         m_stopCondition.wait(m_loopLock);
 }
+
+#if USE(BUN_EVENT_LOOP)
+#define RunLoop RunLoop::RunLoopGenericState
+#endif
 
 inline bool RunLoop::populateTasks(RunMode runMode, Status& statusOfThisLoop, Deque<Ref<TimerBase::ScheduledTask>>& firedTimers)
 {
@@ -174,13 +187,23 @@ inline bool RunLoop::populateTasks(RunMode runMode, Status& statusOfThisLoop, De
 
 void RunLoop::runImpl(RunMode runMode)
 {
+#if USE(BUN_EVENT_LOOP)
+#undef RunLoop
+    ASSERT(&m_parent == &RunLoop::current());
+#define RunLoop RunLoop::RunLoopGenericState
+#else
     ASSERT(this == &RunLoop::current());
+#endif
 
     if constexpr (report) {
         static LazyNeverDestroyed<Timer> reporter;
         static std::once_flag onceKey;
         std::call_once(onceKey, [&] {
+#if USE(BUN_EVENT_LOOP)
+            reporter.construct(m_parent, [this] {
+#else
             reporter.construct(*this, [this] {
+#endif
                 unsigned count = 0;
                 unsigned active = 0;
                 for (auto task = m_schedules.first(); task; task = task->successor()) {
@@ -227,10 +250,18 @@ void RunLoop::runImpl(RunMode runMode)
                 scheduleWithLock(task.get());
             }
         }
+#if USE(BUN_EVENT_LOOP)
+        m_parent.performWork();
+#else
         performWork();
+#endif
     }
 }
 
+// RunLoop::run() is defined in RunLoopBun.cpp
+// RunLoop::setWakeUpCallback() is left undefined as it only exists for the generic and Windows
+// run loops.
+#if !USE(BUN_EVENT_LOOP)
 void RunLoop::run()
 {
     RunLoop::current().runImpl(RunMode::Drain);
@@ -240,6 +271,7 @@ void RunLoop::setWakeUpCallback(WTF::Function<void()>&& function)
 {
     RunLoop::current().m_wakeUpCallback = WTFMove(function);
 }
+#endif
 
 // RunLoop operations are thread-safe. These operations can be called from outside of the RunLoop's thread.
 // For example, WorkQueue::{dispatch, dispatchAfter} call the operations of the WorkQueue thread's RunLoop
@@ -273,11 +305,13 @@ void RunLoop::wakeUp()
     wakeUpWithLock();
 }
 
+#if !USE(BUN_EVENT_LOOP)
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
     RunLoop::current().runImpl(RunMode::Iterate);
     return CycleResult::Continue;
 }
+#endif
 
 void RunLoop::scheduleWithLock(TimerBase::ScheduledTask& task)
 {
@@ -295,21 +329,36 @@ void RunLoop::unscheduleWithLock(TimerBase::ScheduledTask& task)
     }
 }
 
+#if USE(BUN_EVENT_LOOP)
+#undef RunLoop
+#define m_runLoop (m_runLoop->m_genericState)
+#endif
+
 // Since RunLoop does not own the registered TimerBase,
 // TimerBase and its owner should manage these lifetime.
+#if !USE(BUN_EVENT_LOOP)
 RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
     : m_runLoop(WTFMove(runLoop))
     , m_scheduledTask(ScheduledTask::create(*this))
 {
 }
+#endif
 
+#if USE(BUN_EVENT_LOOP)
+void RunLoop::TimerBase::destructGeneric()
+#else
 RunLoop::TimerBase::~TimerBase()
+#endif
 {
     Locker locker { m_runLoop->m_loopLock };
     stopWithLock();
 }
 
+#if USE(BUN_EVENT_LOOP)
+void RunLoop::TimerBase::startGeneric(Seconds interval, bool repeating)
+#else
 void RunLoop::TimerBase::start(Seconds interval, bool repeating)
+#endif
 {
     Locker locker { m_runLoop->m_loopLock };
     stopWithLock();
@@ -324,13 +373,21 @@ void RunLoop::TimerBase::stopWithLock()
     m_scheduledTask->deactivate();
 }
 
+#if USE(BUN_EVENT_LOOP)
+void RunLoop::TimerBase::stopGeneric()
+#else
 void RunLoop::TimerBase::stop()
+#endif
 {
     Locker locker { m_runLoop->m_loopLock };
     stopWithLock();
 }
 
+#if USE(BUN_EVENT_LOOP)
+bool RunLoop::TimerBase::isActiveGeneric() const
+#else
 bool RunLoop::TimerBase::isActive() const
+#endif
 {
     Locker locker { m_runLoop->m_loopLock };
     return isActiveWithLock();
@@ -341,12 +398,20 @@ bool RunLoop::TimerBase::isActiveWithLock() const
     return m_scheduledTask->isActive();
 }
 
+#if USE(BUN_EVENT_LOOP)
+Seconds RunLoop::TimerBase::secondsUntilFireGeneric() const
+#else
 Seconds RunLoop::TimerBase::secondsUntilFire() const
+#endif
 {
     Locker locker { m_runLoop->m_loopLock };
     if (isActiveWithLock())
         return std::max<Seconds>(m_scheduledTask->scheduledTimePoint() - MonotonicTime::now(), 0_s);
     return 0_s;
 }
+
+#if USE(BUN_EVENT_LOOP)
+#undef m_runLoop
+#endif
 
 } // namespace WTF

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -121,6 +121,8 @@ private:
 };
 
 #if USE(BUN_EVENT_LOOP)
+// This constructor and destructor can't be fixed by the `#define RunLoop RunLoop::RunLoopGenericState`
+// because that would make their names include `RunLoop::` twice.
 RunLoop::RunLoopGenericState::RunLoopGenericState(RunLoop& parent)
     : m_parent(parent)
 #else
@@ -145,6 +147,7 @@ RunLoop::~RunLoop()
 }
 
 #if USE(BUN_EVENT_LOOP)
+// Make the following member functions be defined on the right class
 #define RunLoop RunLoop::RunLoopGenericState
 #endif
 
@@ -188,8 +191,12 @@ inline bool RunLoop::populateTasks(RunMode runMode, Status& statusOfThisLoop, De
 void RunLoop::runImpl(RunMode runMode)
 {
 #if USE(BUN_EVENT_LOOP)
+    // We need to #undef because RunLoopGenericState doesn't have a current()
+    // And we need &m_parent instead of `this` because `this` is a RunLoopGenericState,
+    // not a RunLoop.
 #undef RunLoop
     ASSERT(&m_parent == &RunLoop::current());
+    // Undo the #undef above
 #define RunLoop RunLoop::RunLoopGenericState
 #else
     ASSERT(this == &RunLoop::current());
@@ -200,6 +207,7 @@ void RunLoop::runImpl(RunMode runMode)
         static std::once_flag onceKey;
         std::call_once(onceKey, [&] {
 #if USE(BUN_EVENT_LOOP)
+            // construct() needs a RunLoop, not a RunLoopGenericState
             reporter.construct(m_parent, [this] {
 #else
             reporter.construct(*this, [this] {
@@ -251,6 +259,8 @@ void RunLoop::runImpl(RunMode runMode)
             }
         }
 #if USE(BUN_EVENT_LOOP)
+        // This function is defined on RunLoop, not RunLoopGenericState (and it's in RunLoop.cpp so
+        // it isn't getting moved to RunLoopGenericState)
         m_parent.performWork();
 #else
         performWork();
@@ -258,10 +268,10 @@ void RunLoop::runImpl(RunMode runMode)
     }
 }
 
+#if !USE(BUN_EVENT_LOOP)
 // RunLoop::run() is defined in RunLoopBun.cpp
 // RunLoop::setWakeUpCallback() is left undefined as it only exists for the generic and Windows
-// run loops.
-#if !USE(BUN_EVENT_LOOP)
+// run loops, so the rest of WebKit would never call it with USE(BUN_EVENT_LOOP) defined
 void RunLoop::run()
 {
     RunLoop::current().runImpl(RunMode::Drain);
@@ -331,12 +341,17 @@ void RunLoop::unscheduleWithLock(TimerBase::ScheduledTask& task)
 
 #if USE(BUN_EVENT_LOOP)
 #undef RunLoop
+// Now we have to make the TimerBase implementations work. They all access fields on m_runLoop, but
+// those fields won't exist anymore since we moved them to RunLoopGenericState. So we need to make
+// them access m_genericState (this is undefined behavior if m_genericState is nullopt, but none
+// of these functions should even get called if the run loop is not the generic implementation).
 #define m_runLoop (m_runLoop->m_genericState)
 #endif
 
 // Since RunLoop does not own the registered TimerBase,
 // TimerBase and its owner should manage these lifetime.
 #if !USE(BUN_EVENT_LOOP)
+// For Bun, this is defined in RunLoopBun.cpp
 RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
     : m_runLoop(WTFMove(runLoop))
     , m_scheduledTask(ScheduledTask::create(*this))
@@ -345,6 +360,8 @@ RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop)
 #endif
 
 #if USE(BUN_EVENT_LOOP)
+// For Bun, ~TimerBase() is defined in RunLoopBun.cpp and it will call destructGeneric() if it
+// needs to.
 void RunLoop::TimerBase::destructGeneric()
 #else
 RunLoop::TimerBase::~TimerBase()


### PR DESCRIPTION
We'll use the generic one if there is no Bun VM on the current thread (this includes the JSC shell, where there's no Bun code at all), and otherwise the Bun one (which only works enough for the GC timer).

I've tried to minimize the additional difficulty, after merging these changes, of future WebKit upgrades. Most of the new changes from upstream (ignoring changes that were already done in #71, or changes to `RunLoopBun.cpp`) are of the form:

```diff
+ #if USE(BUN_EVENT_LOOP)
+ different thing
+ #else
  existing WebKit code
+ #endif
```

`WTF::RunLoop` is designed to have only one implementation compiled in, depending on build configuration. Bun would like to use either the implementation for `GENERIC_EVENT_LOOP`, on threads that do not have a virtual machine (because these threads don't have a Bun event loop), or a Bun-specific implementation that stubs almost all functionality except that needed for `JSRunLoopTimer` (we integrate those timers into our event loop so that we do GC work at the times JSC wants to). `RunLoop` has some fields that always exist, and some fields that are enabled depending on which kind of `RunLoop` is being used. Our solution is to, when `USE(BUN_EVENT_LOOP)` is true, move all the fields specific to `GENERIC_EVENT_LOOP` into a separate class (`RunLoop::RunLoopGenericState`), and then give `RunLoop` a `std::optional` of that class. When a `RunLoop` is created, if there is a Bun VM on its thread, we use the stub implementation; otherwise, we initialize `m_genericState` and use those functions.

Since `RunLoopGeneric.cpp` is not compiled in when building for Bun, we `#include` it in `RunLoop.cpp` and use some `#defines` to make it define member functions of `RunLoop::RunLoopGenericState` instead of `RunLoop`.
