### PR TITLE
Expose bytecode/GlobalCodeBlock.h and bytecode/ProgramCodeBlock.h

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1410,6 +1410,9 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
 
     heap/BunV8HeapSnapshotBuilder.h
     heap/HeapProfiler.h
+
+    bytecode/GlobalCodeBlock.h
+    bytecode/ProgramCodeBlock.h
 )
 
 if(USE_INSPECTOR_SOCKET_SERVER)


### PR DESCRIPTION
Allows two headers needed for supporting `cachedData` in node:vm to be used in Bun.