### PR TITLE
Expose ModuleAnalyzer and other headers

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1412,6 +1412,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/HeapProfiler.h
 
     bytecode/GlobalCodeBlock.h
+    bytecode/ModuleProgramCodeBlock.h
     bytecode/ProgramCodeBlock.h
     parser/ModuleAnalyzer.h
 )

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1413,6 +1413,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
 
     bytecode/GlobalCodeBlock.h
     bytecode/ProgramCodeBlock.h
+    parser/ModuleAnalyzer.h
 )
 
 if(USE_INSPECTOR_SOCKET_SERVER)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -554,6 +554,7 @@ public:
     FunctionExecutable* functionDecl(int index) { return m_functionDecls[index].get(); }
     int numberOfFunctionDecls() { return m_functionDecls.size(); }
     FunctionExecutable* functionExpr(int index) { return m_functionExprs[index].get(); }
+    size_t numberOfFunctionExprs() const { return m_functionExprs.size(); }
     
     const BitVector& bitVector(size_t i) { return m_unlinkedCode->bitVector(i); }
 

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -66,6 +66,11 @@ StatementNode* SourceElements::singleStatement() const
     return m_head == m_tail ? m_head : nullptr;
 }
 
+StatementNode* SourceElements::firstStatement() const
+{
+    return m_head;
+}
+
 StatementNode* SourceElements::lastStatement() const
 {
     return m_tail;

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1649,6 +1649,7 @@ namespace JSC {
         void append(StatementNode*);
 
         StatementNode* singleStatement() const;
+        StatementNode* firstStatement() const;
         StatementNode* lastStatement() const;
 
         bool hasCompletionValue() const;
@@ -1989,6 +1990,7 @@ namespace JSC {
             return m_numConstants + 2;
         }
 
+        SourceElements* statements() const { return m_statements; }
         StatementNode* singleStatement() const;
 
         bool hasCompletionValue() const override;
@@ -2121,6 +2123,8 @@ namespace JSC {
     class ModuleDeclarationNode : public StatementNode {
     public:
         virtual bool analyzeModule(ModuleAnalyzer&) = 0;
+        virtual bool isImportDeclarationNode() const { return false; }
+        virtual bool hasAttributesList() const { return false; }
         bool hasCompletionValue() const override { return false; }
         bool isModuleDeclarationNode() const override { return true; }
 
@@ -2135,6 +2139,9 @@ namespace JSC {
             Deferred
         };
         ImportDeclarationNode(const JSTokenLocation&, ImportType, ImportSpecifierListNode*, ModuleNameNode*, ImportAttributesListNode*);
+
+        bool isImportDeclarationNode() const override { return true; }
+        bool hasAttributesList() const override { return true; }
 
         ImportSpecifierListNode* specifierList() const { return m_specifierList; }
         ModuleNameNode* moduleName() const { return m_moduleName; }
@@ -2153,6 +2160,8 @@ namespace JSC {
     class ExportAllDeclarationNode final : public ModuleDeclarationNode {
     public:
         ExportAllDeclarationNode(const JSTokenLocation&, ModuleNameNode*, ImportAttributesListNode*);
+
+        bool hasAttributesList() const override { return true; }
 
         ModuleNameNode* moduleName() const { return m_moduleName; }
         ImportAttributesListNode* attributesList() const { return m_attributesList; }
@@ -2221,6 +2230,8 @@ namespace JSC {
     class ExportNamedDeclarationNode final : public ModuleDeclarationNode {
     public:
         ExportNamedDeclarationNode(const JSTokenLocation&, ExportSpecifierListNode*, ModuleNameNode*, ImportAttributesListNode*);
+
+        bool hasAttributesList() const override { return true; }
 
         ExportSpecifierListNode* specifierList() const { return m_specifierList; }
         ModuleNameNode* moduleName() const { return m_moduleName; }

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -33,6 +33,7 @@
 #include "JSModuleEnvironment.h"
 #include "JSModuleNamespaceObject.h"
 #include "JSModuleRecord.h"
+#include "ObjectConstructor.h"
 #include "SyntheticModuleRecord.h"
 #include "VMTrapsInlines.h"
 #include "WebAssemblyModuleRecord.h"
@@ -171,6 +172,16 @@ AbstractModuleRecord* AbstractModuleRecord::hostResolveImportedModule(JSGlobalOb
     JSValue entry = m_dependenciesMap->JSMap::get(globalObject, moduleNameValue);
     RETURN_IF_EXCEPTION(scope, nullptr);
     RELEASE_AND_RETURN(scope, entry.getAs<AbstractModuleRecord*>(globalObject, Identifier::fromString(vm, "module"_s)));
+}
+
+void AbstractModuleRecord::setImportedModule(JSGlobalObject* globalObject, const Identifier& moduleName, AbstractModuleRecord* record)
+{
+    VM& vm = globalObject->vm();
+    JSValue moduleNameValue = identifierToJSValue(vm, moduleName);
+    JSObject* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
+    object->putDirect(vm, PropertyName(Identifier::fromString(vm, "module"_s)), record);
+    // TODO(@heimskr): perhaps more properties, such as state
+    m_dependenciesMap->JSMap::set(globalObject, moduleNameValue, object);
 }
 
 auto AbstractModuleRecord::resolveImport(JSGlobalObject* globalObject, const Identifier& localName) -> Resolution

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -149,6 +149,7 @@ public:
     Resolution resolveImport(JSGlobalObject*, const Identifier& localName);
 
     AbstractModuleRecord* hostResolveImportedModule(JSGlobalObject*, const Identifier& moduleName);
+    void setImportedModule(JSGlobalObject*, const Identifier& moduleName, AbstractModuleRecord*);
 
     JSModuleNamespaceObject* getModuleNamespace(JSGlobalObject*, bool shouldPreventExtensions = true);
     

--- a/Source/JavaScriptCore/runtime/Watchdog.h
+++ b/Source/JavaScriptCore/runtime/Watchdog.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -47,6 +47,7 @@ public:
 
     typedef bool (*ShouldTerminateCallback)(JSGlobalObject*, void* data1, void* data2);
     void setTimeLimit(Seconds limit, ShouldTerminateCallback = nullptr, void* data1 = nullptr, void* data2 = nullptr);
+    Seconds getTimeLimit() const { return m_timeLimit; }
 
     bool shouldTerminate(JSGlobalObject*);
 


### PR DESCRIPTION
Exposes some headers and adds some getters. This is necessary for node:vm support.