### PR TITLE
Disable an assertion for oven-sh/bun#20503

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -56,8 +56,8 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     m_ticket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::AtSomePoint, vm, promise, WTFMove(dependencies));
 #ifndef BUN_SKIP_FAILING_ASSERTIONS
     ASSERT(vm.deferredWorkTimer->hasPendingWork(m_ticket));
-#endif
     ASSERT(!importObject || vm.deferredWorkTimer->hasDependencyInPendingWork(m_ticket, importObject));
+#endif
 }
 
 StreamingCompiler::~StreamingCompiler()


### PR DESCRIPTION
There's a strange assertion in WasmStreamingCompiler.cpp that is suspiciously located near a disabled assertion; it turns out disabling that assertion too allows my PR to work.