### PR TITLE
JSC: fix exception checker error in ObjectConstructor.cpp

### DIFF
--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -660,7 +660,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
     if (targetValue.isUndefinedOrNull())
         return throwVMTypeError(globalObject, scope, "Object.values requires that input parameter not be null or undefined"_s);
 
-    return JSValue::encode(objectValues(vm, globalObject, targetValue));
+    RELEASE_AND_RETURN(scope, JSValue::encode(objectValues(vm, globalObject, targetValue)));
 }
 
 // https://tc39.github.io/ecma262/#sec-topropertydescriptor


### PR DESCRIPTION
found in `test/js/node/test/parallel/test-cluster-disconnect-idle-worker.js`

before:

![image](https://github.com/user-attachments/assets/75f61ded-8dab-4c76-a325-305d0511d836)
