### PR TITLE
Update TestReporter.json

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/TestReporter.json
+++ b/Source/JavaScriptCore/inspector/protocol/TestReporter.json
@@ -30,13 +30,6 @@
           "description": "Unique identifier of the test that was found."
         },
         {
-          "name": "type",
-          "type": "string",
-          "enum": ["test", "describe"],
-          "description": "Type of the item found (test or describe block).",
-          "optional": true
-        },
-        {
           "name": "scriptId",
           "$ref": "Debugger.ScriptId",
           "description": "Unique identifier of the script the test is in. Available when the debugger is attached.",
@@ -57,6 +50,13 @@
           "name": "name",
           "type": "string",
           "description": "Name of the test that started.",
+          "optional": true
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "enum": ["test", "describe"],
+          "description": "Type of the item found (test or describe block).",
           "optional": true
         },
         {

--- a/Source/JavaScriptCore/inspector/protocol/TestReporter.json
+++ b/Source/JavaScriptCore/inspector/protocol/TestReporter.json
@@ -7,7 +7,7 @@
     {
       "id": "TestStatus",
       "type": "string",
-      "enum": ["pass", "fail", "timeout", "skip", "todo"]
+      "enum": ["pass", "fail", "timeout", "skip", "todo", "skipped_because_label"]
     }
   ],
   "commands": [
@@ -24,7 +24,18 @@
     {
       "name": "found",
       "parameters": [
-        { "name": "id", "type": "integer", "description": "Unique identifier of the test that was found." },
+        {
+          "name": "id",
+          "type": "integer",
+          "description": "Unique identifier of the test that was found."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "enum": ["test", "describe"],
+          "description": "Type of the item found (test or describe block).",
+          "optional": true
+        },
         {
           "name": "scriptId",
           "$ref": "Debugger.ScriptId",
@@ -42,7 +53,18 @@
           "type": "integer",
           "description": "Line number in the script that started the test."
         },
-        { "name": "name", "type": "string", "description": "Name of the test that started.", "optional": true }
+        {
+          "name": "name",
+          "type": "string",
+          "description": "Name of the test that started.",
+          "optional": true
+        },
+        {
+          "name": "parentId",
+          "type": "integer",
+          "description": "ID of the parent describe block, if any.",
+          "optional": true
+        }
       ]
     },
     {


### PR DESCRIPTION
More info to help with vscode extension reporter. The parent test is important to know the test tree. The type is helpful as a result of wanting to make the tree so we know more about whats happening.

 And the skipped_because_label is just helpful as we may as well see all tests, but this distinction helps us know if it was normally skipped or via the --test-name-pattern (not too important, but what do we loose with it)