### PR TITLE
async function should return default promise in node:fs/promises

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -789,8 +789,22 @@ IGNORE_GCC_WARNINGS_END
 
         emitNewGenerator(m_generatorRegister);
         bool isInternalPromise = false;
+#if USE(BUN_JSC_ADDITIONS)
+        if (m_isBuiltinFunction) {
+            const auto isDefaultPromiseForBun = [&]() -> bool {
+                if (auto* provider = m_scopeNode->source().provider()) {
+                    const String& sourceURL = provider->sourceURL();
+                    if (!sourceURL.isNull() && !sourceURL.isEmpty())
+                        return sourceURL == "node:fs/promises"_s;
+                }
+                return false;
+            };
+            isInternalPromise = !functionNode->ident().string().startsWith("defaultAsync"_s) && !isDefaultPromiseForBun();
+        }
+#else
         if (m_isBuiltinFunction)
             isInternalPromise = !functionNode->ident().string().startsWith("defaultAsync"_s);
+#endif
         emitNewPromise(promiseRegister(), isInternalPromise);
         emitPutInternalField(generatorRegister(), static_cast<unsigned>(JSGenerator::Field::Context), promiseRegister());
         break;


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/22167

JSC generates bytecode so that async functions defined within built-in JS code return `JSInternalPromise` instead of the default Promise. This is intentional, but this caused Bun's node:fs/promises exported functions to incorrectly return `JSInternalPromise`.

This patch changes it to return the appropriate Promise by checking the source URL where the built-in is defined.
