### PR TITLE
Fix to enable async stack trace

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -505,9 +505,9 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
                 // If a CodeBlock doesn't already exist, the stack trace will only show the filename and won't show line column
                 if (CodeBlock* codeBlock = executable->codeBlockForCall()) {
                     BytecodeIndex bytecodeIndex = computeBytecodeIndex(codeBlock, currentGenerator);
-                    results.append(StackFrame(vm, owner, asyncFunction, codeBlock, bytecodeIndex));
+                    results.append(StackFrame(vm, owner, asyncFunction, codeBlock, bytecodeIndex, /* isAsyncFrame */ true));
                 } else
-                    results.append(StackFrame(vm, owner, asyncFunction, /* isAsyncFrameWithoutCodeBlock */ true));
+                    results.append(StackFrame(vm, owner, asyncFunction, /* isAsyncFrame */ true));
             }
         }
         currentGenerator = getParentGenerator(currentGenerator);

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -620,6 +620,10 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
 #else
         } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction())
 #endif
+#if USE(BUN_JSC_ADDITIONS)
+            // FIXME: Remove this BUN_JSC_ADDITIONS when https://github.com/WebKit/WebKit/pull/50288 has been merged
+            if (!isAsyncFunctionWrapperParseMode(visitor->codeBlock()->unlinkedCodeBlock()->parseMode()))
+#endif
             results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
         else
             results.append(StackFrame(vm, owner, visitor->callee().asCell()));

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -99,6 +99,7 @@ public:
     }
 
 #if USE(BUN_JSC_ADDITIONS)
+    // FIXME: Remove this BUN_JSC_ADDITIONS when added into upstream
     bool isAsyncFrame() const
     {
         if (auto* jsFrame = std::get_if<JSFrameData>(&m_frameData))

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -98,11 +98,18 @@ public:
         return false;
     }
 
-    bool isAsyncFrameWithoutCodeBlock() const
+#if USE(BUN_JSC_ADDITIONS)
+    bool isAsyncFrame() const
     {
         if (auto* jsFrame = std::get_if<JSFrameData>(&m_frameData))
-            return jsFrame->m_isAsyncFrame && !codeBlock();
+            return jsFrame->m_isAsyncFrame;
         return false;
+    }
+#endif
+
+    bool isAsyncFrameWithoutCodeBlock() const
+    {
+        return isAsyncFrame() && !codeBlock();
     }
 
     LineColumn computeLineAndColumn() const;

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -44,7 +44,7 @@ struct JSFrameData {
     WriteBarrier<JSCell> callee;
     WriteBarrier<CodeBlock> codeBlock;
     BytecodeIndex bytecodeIndex;
-    bool m_isAsyncFrameWithoutCodeBlock { false };
+    bool m_isAsyncFrame { false };
 };
 
 struct WasmFrameData {
@@ -58,8 +58,9 @@ public:
 
     StackFrame(VM&, JSCell* owner, JSCell* callee);
     StackFrame(VM&, JSCell* owner, JSCell* callee, CodeBlock*, BytecodeIndex);
+    StackFrame(VM&, JSCell* owner, JSCell* callee, CodeBlock*, BytecodeIndex, bool isAsyncFrame);
     StackFrame(VM&, JSCell* owner, CodeBlock*, BytecodeIndex);
-    StackFrame(VM&, JSCell* owner, JSCell* callee, bool isAsyncFrameWithoutCodeBlock);
+    StackFrame(VM&, JSCell* owner, JSCell* callee, bool isAsyncFrame);
     StackFrame(Wasm::IndexOrName);
     StackFrame(Wasm::IndexOrName, size_t functionIndex);
     StackFrame() = default;
@@ -94,6 +95,13 @@ public:
     {
         if (auto* jsFrame = std::get_if<JSFrameData>(&m_frameData))
             return !!jsFrame->codeBlock;
+        return false;
+    }
+
+    bool isAsyncFrameWithoutCodeBlock() const
+    {
+        if (auto* jsFrame = std::get_if<JSFrameData>(&m_frameData))
+            return jsFrame->m_isAsyncFrame && !codeBlock();
         return false;
     }
 


### PR DESCRIPTION
This PR does following to enable async stack trace:

- Apply https://github.com/oven-sh/WebKit/commit/5dd8842ba4a06129cdf32b13f7bc44f395ad9c93 again
- Add `isAsyncFrame` method to `StackFrame` ( Will upstream if possible )
- Hide async function wrapper frame from stack traces (Will upstream )
