### PR TITLE
Remove `BUN_JSC_ADDITION` that was added for hide extra frame

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -620,10 +620,6 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
 #else
         } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction())
 #endif
-#if USE(BUN_JSC_ADDITIONS)
-            // FIXME: Remove this BUN_JSC_ADDITIONS when https://github.com/WebKit/WebKit/pull/50288 has been merged
-            if (!isAsyncFunctionWrapperParseMode(visitor->codeBlock()->unlinkedCodeBlock()->parseMode()))
-#endif
             results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
         else
             results.append(StackFrame(vm, owner, visitor->callee().asCell()));


### PR DESCRIPTION
Build failing on https://github.com/oven-sh/bun/pull/22517 is caused by this `BUN_JSC_ADDITION`.

So remove it for now.
